### PR TITLE
Fix Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM rust:1-alpine-3.19 AS builder
+FROM rust:1-alpine AS builder
 
 WORKDIR /app
+RUN apk add --no-cache editorconfig-dev
 COPY Cargo.toml Cargo.lock ./
-RUN mkdir src && echo "fn main() {println!(\"if you see this, the build broke\")}" > src/main.rs && cargo build --release && rm -f src/main.rs
-
-COPY src ./src
-RUN CARGO_BUILD_INCREMENTAL=true cargo build --release
+COPY crates ./crates
+RUN RUSTFLAGS="-C target-feature=-crt-static -L native=/usr/lib" cargo build --locked --release --package ecci
 
 FROM alpine:3.19 AS runtime
+RUN apk add --no-cache libeditorconfig libgcc
 COPY --from=builder /app/target/release/ecci /usr/local/bin/ecci
 
 FROM runtime AS action

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM rust:1-alpine AS builder
 
 WORKDIR /app
-RUN apk add --no-cache editorconfig-dev
+RUN apk add --no-cache editorconfig-dev=0.12.11-r0
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 RUN RUSTFLAGS="-C target-feature=-crt-static -L native=/usr/lib" cargo build --locked --release --package ecci
 
 FROM alpine:3.19 AS runtime
-RUN apk add --no-cache libeditorconfig libgcc
+RUN apk add --no-cache libeditorconfig=0.12.6-r2 libgcc=13.2.1_git20231014-r0
 COPY --from=builder /app/target/release/ecci /usr/local/bin/ecci
 
 FROM runtime AS action


### PR DESCRIPTION
## Summary
- update the unavailable Rust Alpine base image tag
- build the current Cargo workspace and install EditorConfig dependencies
- add required runtime libraries

## Root cause
The old Rust image tag no longer exists, and the Dockerfile still copied the pre-workspace `src/` layout.

## Validation
- `docker build -t ecci-test .`
- `docker run --rm -v "$PWD":/work -w /work ecci-test`