### PR TITLE
fix: silence charset checker unused variable warnings

### DIFF
--- a/crates/ecci-checker/src/charset.rs
+++ b/crates/ecci-checker/src/charset.rs
@@ -3,10 +3,10 @@ use ecci_editorconfig::Config;
 use crate::Output;
 
 pub fn check_charset<T: Output>(
-    config: &Config,
-    output: &mut T,
-    line_number: usize,
-    content: &str,
+    _config: &Config,
+    _output: &mut T,
+    _line_number: usize,
+    _content: &str,
 ) {
     // todo!();
 }


### PR DESCRIPTION
## Summary
- mark unused arguments in the charset checker stub as intentionally unused
- preserve the existing checker interface and behavior

## Validation
- cargo build -p ecci-checker
- cargo test -p ecci-checker