### PR TITLE
Improve CI build caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+target
+.github
+.devcontainer
+CHANGELOG.md
+LICENSE
+README.md
+testdata

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,55 @@
+name: Docker build
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'action.yml'
+      - 'entrypoint.sh'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**'
+      - '.github/workflows/docker-build.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'action.yml'
+      - 'entrypoint.sh'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**'
+      - '.github/workflows/docker-build.yml'
+
+# The GHA cache backend uses the Actions runtime token. No repository write
+# permission or secrets are exposed to Docker builds from pull requests.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Docker action
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # GitHub scopes caches by ref: PR runs can restore the base/default-branch
+      # cache, while their exports remain isolated to the PR ref.
+      - name: Build Docker action
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          target: action
+          push: false
+          cache-from: type=gha,scope=ecci-docker-build
+          cache-to: type=gha,mode=max,scope=ecci-docker-build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
 
+permissions:
+  contents: read
+
 env:
   RUST_LOG: info
   RUST_BACKTRACE: 1
@@ -53,6 +56,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup toolchain
         run: rustup toolchain install nightly
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Install udeps
         run: cargo install cargo-udeps --locked
       - name: Run udeps

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,6 +10,9 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -58,6 +61,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup toolchain
         run: rustup toolchain install nightly
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
       - name: Install udeps
         run: cargo install cargo-udeps --locked
       - name: Run udeps

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,19 @@ FROM rust:1-alpine AS builder
 
 WORKDIR /app
 RUN apk add --no-cache editorconfig-dev=0.12.11-r0
+
+# Fetching is keyed only by the manifests and lockfile. Keep it before the
+# source copy so a source-only change can reuse this layer from BuildKit's cache.
 COPY Cargo.toml Cargo.lock ./
+COPY crates/ecci/Cargo.toml crates/ecci/Cargo.toml
+COPY crates/ecci-checker/Cargo.toml crates/ecci-checker/Cargo.toml
+COPY crates/ecci-editorconfig/Cargo.toml crates/ecci-editorconfig/Cargo.toml
+# Cargo validates every workspace member before fetching. These placeholder
+# targets make the manifest-only workspace valid without copying real sources.
+RUN mkdir -p crates/ecci/src crates/ecci-checker/src crates/ecci-editorconfig/src \
+    && touch crates/ecci/src/main.rs crates/ecci-checker/src/lib.rs crates/ecci-editorconfig/src/lib.rs
+RUN cargo fetch --locked
+
 COPY crates ./crates
 RUN RUSTFLAGS="-C target-feature=-crt-static -L native=/usr/lib" cargo build --locked --release --package ecci
 


### PR DESCRIPTION
## Summary
- add BuildKit GitHub Actions cache support for Docker action builds
- reorder Dockerfile dependency fetching to preserve cache hits on source-only changes
- cache Rust dependencies and cargo-udeps for dependency checks

## Validation
- docker build --target action (second build reported cached layers)
- actionlint
- git diff --check