### PR TITLE
chore: update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/action-lint.yml
+++ b/.github/workflows/action-lint.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.21
           cache: false
@@ -28,7 +28,7 @@ jobs:
       #   run: go install github.com/rhysd/actionlint/cmd/actionlint@latest
 
       - name: Checkout Actions Lint fork
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: kounoike/actionlint
           ref: inline-ignore

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -37,15 +37,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # GitHub scopes caches by ref: PR runs can restore the base/default-branch
       # cache, while their exports remain isolated to the PR ref.
       - name: Build Docker action
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Hadolint
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: Dockerfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Rust
         uses: moonrepo/setup-rust@v1
         with:
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Rust
         uses: moonrepo/setup-rust@v1
         with:
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup toolchain
         run: rustup toolchain install nightly
       - name: Restore Rust cache
@@ -72,4 +72,4 @@ jobs:
     needs: [format, lint, check-dependencies]
     runs-on: ubuntu-latest
     steps:
-      - uses: Kesin11/actions-timeline@v2
+      - uses: Kesin11/actions-timeline@v3

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -33,6 +33,6 @@ jobs:
           files_to_ignore: |
             "Cargo.lock"
       - name: Autolabeler by release-drafter
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Rust
         uses: moonrepo/setup-rust@v1
         with:
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Rust
         uses: moonrepo/setup-rust@v1
         with:
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup toolchain
         run: rustup toolchain install nightly
       - name: Restore Rust cache
@@ -77,4 +77,4 @@ jobs:
     needs: [format, lint, check-dependencies]
     runs-on: ubuntu-latest
     steps:
-      - uses: Kesin11/actions-timeline@v2
+      - uses: Kesin11/actions-timeline@v3

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: tagpr
       uses: Songmu/tagpr@v1
       env:

--- a/.github/workflows/update-semver.yml
+++ b/.github/workflows/update-semver.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: haya14busa/action-update-semver@v1
         with:
           major_version_tag_only: true


### PR DESCRIPTION
## Summary
- update GitHub Actions dependencies to their current stable major versions
- retain the repository's Dependabot-compatible tag pinning policy
- keep existing workflow inputs and least-privilege permissions

## Validation
- actionlint (project fork)
- git diff --check
- docker build --target action
- cargo fmt --all -- --check
- cargo check --workspace --all-targets --release
- cargo test --workspace