### PR TITLE
fix: handle unset and invalid indent size

### DIFF
--- a/crates/ecci-checker/src/indent_size.rs
+++ b/crates/ecci-checker/src/indent_size.rs
@@ -9,7 +9,7 @@ pub fn check_indent_size<T: Output>(
     content: &str,
 ) {
     if let Some(IndentStyle::Space) = config.indent_style {
-        if let Some(size) = config.indent_size {
+        if let Some(size) = config.indent_size.filter(|size| *size > 0) {
             let mut indent = 0;
             for c in content.chars() {
                 if c == ' ' {
@@ -117,7 +117,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "known defect: the editorconfig adapter panics when indent_size = unset"]
     fn check_indent_size_unset_disables_inherited_size() {
         let target_path = "../../testdata/indent_size/unset/unset.target";
         let config =
@@ -191,7 +190,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "known defect: invalid indent_size makes the editorconfig adapter panic"]
     fn invalid_indent_size_returns_an_error() {
         let target_path = "../../testdata/indent_size/invalid_value/invalid.target";
         let result = ecci_editorconfig::Config::from_path(std::path::Path::new(target_path));
@@ -199,7 +197,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "known defect: indent_size = 0 causes a division-by-zero panic"]
     fn zero_indent_size_does_not_panic() {
         let target_path = "../../testdata/indent_size/zero/zero.target";
         let config =

--- a/crates/ecci-editorconfig/src/lib.rs
+++ b/crates/ecci-editorconfig/src/lib.rs
@@ -1,4 +1,5 @@
 use std::ffi::CString;
+use std::io::{Error, ErrorKind};
 use std::path::{Path, PathBuf};
 
 #[allow(dead_code, non_camel_case_types)]
@@ -66,6 +67,7 @@ fn parse_internal(path: &Path) -> std::io::Result<Config> {
         let handle = bindings::editorconfig_handle_init();
         bindings::editorconfig_parse(ptr, handle);
         let count = bindings::editorconfig_handle_get_name_value_count(handle);
+        let mut parse_error = None;
         for i in 0..count {
             let mut name: *const i8 = std::ptr::null();
             let mut value: *const i8 = std::ptr::null();
@@ -79,14 +81,43 @@ fn parse_internal(path: &Path) -> std::io::Result<Config> {
                     _ => {}
                 },
                 "indent_size" => {
-                    if value == "tab" {
+                    if value == "unset" {
+                        config.indent_size = None;
+                        config.indent_size_is_tab = false;
+                    } else if value == "tab" {
+                        config.indent_size = None;
                         config.indent_size_is_tab = true;
                     } else {
-                        config.indent_size = Some(value.parse().unwrap());
+                        let size = match value.parse() {
+                            Ok(size) => size,
+                            Err(error) => {
+                                parse_error = Some(Error::new(
+                                    ErrorKind::InvalidData,
+                                    format!("invalid indent_size value {value:?}: {error}"),
+                                ));
+                                break;
+                            }
+                        };
+                        config.indent_size = Some(size);
+                        config.indent_size_is_tab = false;
                     }
                 }
                 "tab_width" => {
-                    config.tab_width = Some(value.parse().unwrap());
+                    if value == "unset" {
+                        config.tab_width = None;
+                    } else {
+                        let width = match value.parse() {
+                            Ok(width) => width,
+                            Err(error) => {
+                                parse_error = Some(Error::new(
+                                    ErrorKind::InvalidData,
+                                    format!("invalid tab_width value {value:?}: {error}"),
+                                ));
+                                break;
+                            }
+                        };
+                        config.tab_width = Some(width);
+                    }
                 }
                 "end_of_line" => match value {
                     "lf" => config.end_of_line = Some(EndOfLine::LF),
@@ -117,6 +148,9 @@ fn parse_internal(path: &Path) -> std::io::Result<Config> {
         let ret = bindings::editorconfig_handle_destroy(handle);
         if ret != 0 {
             panic!("Failed to destroy the editorconfig_handle object");
+        }
+        if let Some(error) = parse_error {
+            return Err(error);
         }
     }
     Ok(config)


### PR DESCRIPTION
## Summary
- treat `indent_size = unset` as an unset inherited value
- return an error rather than panicking for invalid numeric indent sizes
- avoid division by zero for `indent_size = 0`
- enable the Issue #69 regression tests

## Verification
- `cargo fmt --check`
- `cargo test -p ecci-editorconfig`
- `cargo test -p ecci-checker indent_size`
- `cargo test -p ecci-checker tab_width`

`cargo test --workspace` still has unrelated existing failures for `insert_final_newline = unset` and `max_line_length = unset`.