### PR TITLE
docs: establish documentation governance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ GitHub Action.
 
 ## Working rules
 
-- Write repository documentation, issues, pull-request titles and descriptions,
-  and review comments in English.
+- Write repository documentation, source-code comments, issues, pull-request
+  titles and descriptions, and review comments in English.
 - Communicate with users in their preferred language. This exception does not
   apply to repository artifacts, which must be written in English.
 - Keep `README.md` brief and human-facing: purpose, installation, basic usage,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ GitHub Action.
 
 - Write repository documentation, issues, pull-request titles and descriptions,
   and review comments in English.
+- Communicate with users in their preferred language. This exception does not
+  apply to repository artifacts, which must be written in English.
 - Keep `README.md` brief and human-facing: purpose, installation, basic usage,
   and links only. Put user guidance in `docs/user/`, design rationale in
   `docs/design/`, and contributor workflows in `docs/development/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Coding-agent instructions
+
+## Project
+
+`ecci` is a Rust workspace that checks `.editorconfig` settings and provides a
+GitHub Action.
+
+## Working rules
+
+- Write all repository documentation and documentation changes in English.
+- Keep `README.md` brief and human-facing: purpose, installation, basic usage,
+  and links only. Put user guidance in `docs/user/`, design rationale in
+  `docs/design/`, and contributor workflows in `docs/development/`.
+- Read [documentation governance](docs/design/documentation-governance.md)
+  before creating or restructuring documentation.
+- Update affected documentation when behavior, configuration, diagnostics,
+  action inputs, architecture, or contributor workflow changes.
+- For Rust changes, run the relevant tests; normally use `cargo test --workspace`.
+  Report commands run and results, or explain why verification was not run.
+- Keep changes scoped to the request. Do not alter unrelated code, tests,
+  generated bindings, dependencies, or formatting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,8 @@ GitHub Action.
 
 ## Working rules
 
-- Write all repository documentation and documentation changes in English.
+- Write repository documentation, issues, pull-request titles and descriptions,
+  and review comments in English.
 - Keep `README.md` brief and human-facing: purpose, installation, basic usage,
   and links only. Put user guidance in `docs/user/`, design rationale in
   `docs/design/`, and contributor workflows in `docs/development/`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # ecci
+
+`ecci` is a Rust-based checker for whether files conform to their applicable
+`.editorconfig` settings. It is also packaged as a Docker-based GitHub Action.
+
+## Installation
+
+Install a Rust toolchain, clone this repository, and build the workspace:
+
+```sh
+cargo build --workspace
+```
+
+## Basic usage
+
+Run the current command-line prototype from the repository root:
+
+```sh
+cargo run --package ecci
+```
+
+The prototype currently reads the `.editorconfig` configuration for
+`Cargo.toml` and prints its resolved indentation style.
+
+## Documentation
+
+- [User documentation](docs/user/README.md)
+- [Technical design documentation](docs/design/README.md)
+- [Development documentation](docs/development/README.md)
+- [Documentation governance](docs/design/documentation-governance.md)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,7 @@
+# Technical design documentation
+
+This area records human-facing technical design: architecture decisions,
+invariants, implementation rationale, and cross-cutting technical behavior. It
+is not end-user documentation.
+
+- [Documentation governance](documentation-governance.md)

--- a/docs/design/documentation-governance.md
+++ b/docs/design/documentation-governance.md
@@ -5,6 +5,9 @@
 This policy governs repository documentation. All documentation, including new
 pages and edits to existing pages, must be written in English.
 
+Use English for repository collaboration as well: write issues, pull-request
+titles and descriptions, and review comments in English.
+
 Documentation is written for people. Instructions for coding agents belong in
 the root [AGENTS.md](../../AGENTS.md), with extended agent-only guidance under
 `docs/agents/` when it becomes necessary. Do not place agent instructions in

--- a/docs/design/documentation-governance.md
+++ b/docs/design/documentation-governance.md
@@ -1,0 +1,71 @@
+# Documentation governance
+
+## Scope and language
+
+This policy governs repository documentation. All documentation, including new
+pages and edits to existing pages, must be written in English.
+
+Documentation is written for people. Instructions for coding agents belong in
+the root [AGENTS.md](../../AGENTS.md), with extended agent-only guidance under
+`docs/agents/` when it becomes necessary. Do not place agent instructions in
+human documentation.
+
+## Structure and audiences
+
+| Location | Audience | Purpose |
+| --- | --- | --- |
+| `AGENTS.md` | Coding agents | Concise operational instructions and links to extended agent guidance. |
+| `docs/agents/` | Coding agents | Extended agent-only procedures, if needed. |
+| `README.md` | Project visitors | Brief purpose, installation, basic usage, and links. |
+| `docs/user/` | Users | CLI usage, configuration, diagnostics, and GitHub Action usage. |
+| `docs/design/` | Developers and maintainers | Architecture, decisions, invariants, and implementation rationale. |
+| `docs/development/` | Contributors and maintainers | Contribution, release, testing, and maintenance workflows. |
+
+Keep these boundaries intact. User tasks and tutorials do not belong in design
+documents. Design rationale does not belong in the README except for brief
+context that links to the detailed design. Human-facing documents must not
+embed agent-only instructions.
+
+## Ownership and maintenance
+
+The author of a code, workflow, or interface change owns the matching
+documentation update. Reviewers check that the documentation is accurate,
+appropriately located, linked from its index, and written in English.
+
+Update documentation in the same change when it affects:
+
+- command-line behavior, configuration, output, errors, or diagnostics;
+- GitHub Action behavior, inputs, outputs, or setup;
+- public installation or basic usage information;
+- architecture, invariants, dependencies, or a significant implementation
+  decision; or
+- contributor, test, build, release, or maintenance workflows.
+
+If no documentation changes are needed, state that assessment in the change
+description when it would not be obvious to a reviewer.
+
+## Terminology
+
+- **User documentation** explains how to use `ecci`.
+- **Design documentation** explains why the system is structured or behaves as
+  it does.
+- **Development documentation** explains how people contribute and maintain the
+  repository.
+- **Agent guidance** is operational direction for coding agents and is kept
+  separate from human documentation.
+
+Use the project name `ecci`, the spelling `.editorconfig`, and the terms
+"GitHub Action" and "command-line interface (CLI)" consistently. Define an
+unfamiliar acronym on first use in a page.
+
+## Markdown, linking, and review
+
+Use ATX headings, sentence-style heading capitalization, fenced code blocks
+with a language where known, and relative links. Keep pages focused, use
+descriptive link text, and update the relevant directory index when adding a
+page. Prefer links over duplicating content; the README links to primary docs,
+and each documentation area has an index.
+
+During review, verify that commands, paths, option names, and links are correct;
+that the page serves its declared audience; and that it contains neither stale
+behavior nor content belonging to another documentation area.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,0 +1,6 @@
+# Development documentation
+
+This area contains human-facing contributor and maintainer workflows when they
+need more detail than the repository's standard build and test commands.
+
+There are currently no additional development workflow guides.

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,0 +1,11 @@
+# User documentation
+
+This area contains documentation for people using `ecci`, including command-line
+usage, configuration, diagnostics, and GitHub Action usage.
+
+Add a focused page here when a user-facing feature needs explanation. Link that
+page from this index and, when it is a primary entry point, from the repository
+[README](../../README.md).
+
+For the current command-line prototype, see the [basic usage instructions in
+the README](../../README.md#basic-usage).


### PR DESCRIPTION
## Summary
- add concise coding-agent instructions in AGENTS.md
- establish audience-separated documentation structure and governance
- expand the README with purpose, installation, basic usage, and documentation links

## Verification
- git diff --check
- cargo test --workspace *(fails: existing unset parsing failures in insert_final_newline and max_line_length)*