### PR TITLE
Resolve CLI and GitHub Action design ambiguities

### DIFF
--- a/docs/design/binary-file-detection.md
+++ b/docs/design/binary-file-detection.md
@@ -101,8 +101,11 @@ and [Magika guidance for automated output](https://securityresearch.google/magik
 
 ## Initial embedded classifier
 
-For each regular file, the traversal layer resolves its `.editorconfig`
-settings, reads at most 8 KiB, and classifies the sample in this order:
+For each regular file that remains after ignore selection, the selection layer
+resolves its `.editorconfig` settings, reads at most 8 KiB, and classifies the
+sample in this order. Classification still runs for a candidate marked
+`force_check`; that flag overrides only the subsequent `Binary` exclusion and
+does not alter or short-circuit the classifier:
 
 1. An empty sample is text.
 2. `FF FE` and `FE FF` (UTF-16 little- and big-endian BOMs) are text.
@@ -164,6 +167,9 @@ covered by automated tests:
   reported; without that configuration it follows the ordinary sampled rule.
 - Permission/read errors and optional-detector errors are reported and do not
   silently skip a path.
+- A final `.ecciignore` whitelist still runs and records binary classification,
+  then causes a `Binary` result to reach the checker; tests verify that the
+  classifier itself does not consume or reconstruct ignore state.
 - Directory traversal tests prove binary selection is independent of filename
   extension, and a Docker-action smoke test exercises the same fixtures.
 
@@ -189,6 +195,14 @@ returns `Binary`. This is the escape hatch for text files incorrectly excluded
 by the classifier. It does not make directories or special files checkable,
 and it does not suppress normal I/O or charset errors.
 
+The file-selection layer owns final ignore-rule evaluation and passes a
+structured ignore decision into this classifier. The classifier returns only
+`Text` or `Binary` (or a read error); it neither reruns ignore matching nor
+decides whether a `Binary` result is excluded. The selection layer records the
+classifier result and applies `force_check` afterward. This boundary preserves
+the final matching rule as provenance and prevents a walker eligibility
+boolean from being mistaken for a final whitelist match.
+
 Use the Rust [`ignore` crate](https://docs.rs/ignore/) for traversal and
 `.gitignore`-compatible parsing. `WalkBuilder` can discover
 `.ecciignore` through `add_custom_ignore_filename`; its custom ignore files
@@ -196,8 +210,11 @@ take precedence over standard ignore files. The traversal implementation must
 also retain the `.ecciignore` match result with the candidate path. A walker
 alone only tells `ecci` that the path is eligible for traversal; it does not
 preserve whether eligibility came from a negated pattern. Use the crate's
-lower-level `gitignore::Gitignore` matcher (or an equivalent wrapper) to record
-the final ignore/whitelist match and set `force_check` for a final whitelist.
+lower-level `gitignore::Gitignore` matcher (or an equivalent wrapper) through
+the structured ignore-decision API defined in
+[CLI file selection](cli-file-selection.md#ignore-rules-and-selection-order).
+That API records the final ignore/whitelist match and sets `force_check` for a
+final `.ecciignore` whitelist.
 
 The implementation task must include user documentation under `docs/user/`
 covering location, pattern syntax, precedence with `.gitignore`, negation and
@@ -208,8 +225,6 @@ should remain limited to a link if a user-facing configuration page is added.
 
 - Should a future strict optional-Magika mode fail the command when Magika is
   unavailable, or is fallback-only behaviour sufficient for all users?
-- Should malformed UTF-16 with a configured UTF-16 charset always bypass
-  binary exclusion, as proposed, to guarantee a charset diagnostic?
 - What false-positive/false-negative rate on the evaluation corpus would
   justify the additional image size and supply-chain maintenance?
 - If Magika is adopted, should it be a separately tagged action image or an

--- a/docs/design/binary-file-detection.md
+++ b/docs/design/binary-file-detection.md
@@ -5,8 +5,9 @@
 `ecci` will initially use an embedded, deterministic binary-file classifier. It
 will be mandatory as part of file selection, will read only a bounded prefix,
 and will explicitly recognise UTF-16 before applying a NUL-byte heuristic.
-Files classified as binary are skipped without producing EditorConfig
-diagnostics.
+Files classified as binary are normally skipped without producing EditorConfig
+diagnostics. The documented final `.ecciignore` whitelist is the sole initial
+force-check exception.
 
 The Rust Magika command-line interface (CLI) is **not a required runtime
 dependency** and will not be added to the initial Docker action image. A
@@ -167,9 +168,11 @@ covered by automated tests:
   reported; without that configuration it follows the ordinary sampled rule.
 - Permission/read errors and optional-detector errors are reported and do not
   silently skip a path.
-- A final `.ecciignore` whitelist still runs and records binary classification,
-  then causes a `Binary` result to reach the checker; tests verify that the
-  classifier itself does not consume or reconstruct ignore state.
+- A final `.ecciignore` whitelist is already recorded before classification;
+  classification still runs and records `Binary`, after which `force_check`
+  causes the candidate to reach the checker. Tests verify that the classifier
+  receives only the resolved charset and bytes and does not consume or
+  reconstruct ignore state.
 - Directory traversal tests prove binary selection is independent of filename
   extension, and a Docker-action smoke test exercises the same fixtures.
 

--- a/docs/design/cli-diagnostics-and-github-action.md
+++ b/docs/design/cli-diagnostics-and-github-action.md
@@ -47,7 +47,9 @@ The initial text format is intended for terminals and CI logs, not as a
 machine-readable API. One diagnostic is rendered on one line; the location is
 omitted when unavailable. Findings use `error`, skipped work uses `warning`,
 and fatal execution errors use `error`. Detailed progress is never mixed into
-the diagnostic stream unless requested.
+the diagnostic stream unless requested. Skip diagnostics are not shown by
+default. `--show-skips` requests their `ECCI-SKIP` warning lines; skipped files
+remain counted in either mode.
 
 ```text
 error[ECCI001] src/lib.rs:14:1: indent_style must be space; found tab
@@ -101,12 +103,12 @@ filter matched nothing.
 ## GitHub Action interface
 
 The published Action is a Docker Action that invokes the same checker and
-report model as the CLI. Its first-release interface is proposed as follows:
+report model as the CLI. Its first-release interface is defined as follows:
 
 | Input | Required | Default | Meaning |
 | --- | --- | --- | --- |
-| `paths` | No | `.` | Newline-separated repository-relative files or directories to check. |
-| `working-directory` | No | `${{ github.workspace }}` | Directory used to resolve `paths` and relative locations. It must remain inside the workspace. |
+| `paths` | No | `.` | Newline-separated files or directories, relative to `working-directory`, to check. |
+| `working-directory` | No | `.` | Workspace-relative directory used to resolve `paths`. It must resolve to an existing directory inside the workspace. |
 | `fail-on-violation` | No | `true` | When `true`, violations make the Action fail; when `false`, they are reported but the Action succeeds unless an execution error occurs. |
 | `annotations` | No | `true` | Emit GitHub Actions annotations when running in GitHub Actions. |
 | `summary` | No | `true` | Write the aggregate result to the GitHub Actions job summary. |
@@ -117,6 +119,41 @@ Boolean and numeric inputs must be validated strictly. Invalid input is an
 Action configuration error, produces an `ECCI-CONFIG` annotation when possible,
 and fails the Action. The Action must reject a `working-directory` or path that
 resolves outside `GITHUB_WORKSPACE`.
+
+`GITHUB_WORKSPACE` is the immutable containment and annotation base. The Action
+canonicalizes it first. `working-directory` must be relative (an absolute value
+is rejected), is resolved against that base, and is then canonicalized; it must
+name an existing directory whose resolved location is contained by the
+canonical workspace. The default `.` therefore means the workspace root.
+
+The Action parses `paths` by splitting on lines, removing a trailing carriage
+return, trimming leading and trailing ASCII whitespace from each line, and
+discarding empty lines. GitHub Actions does not reliably distinguish an omitted
+optional string input from an explicitly empty one, so zero entries after this
+processing means one entry, `.`. Paths containing leading or trailing ASCII
+whitespace cannot be expressed through this input. Each entry must be relative;
+absolute paths are configuration errors.
+
+Each path is resolved against the canonical working directory and lexically
+normalized before filesystem access. A lexical `..` is allowed only when the
+normalized result remains within the workspace. Existing paths are then
+canonicalized to resolve symbolic links and must still be contained by the
+canonical workspace. A nonexistent path that is lexically contained proceeds
+to normal selection and becomes `ECCI-IO`; an escape, including an existing
+symlink that resolves outside the workspace, is `ECCI-CONFIG`. Normalized
+entries are de-duplicated in input order before invoking selection. The
+selection layer performs its own resolved-file identity de-duplication, so
+aliases and direct symbolic links that survive containment are also checked
+only once.
+
+CLI text paths are relative to the invocation working directory when possible,
+as specified above. In the Action, all log, summary, and annotation paths are
+instead relative to the canonical workspace, regardless of
+`working-directory`, because workflow annotations use repository-relative
+locations. Rendered paths use forward slashes. A path for which a contained,
+workspace-relative spelling cannot be produced is omitted from an annotation
+rather than rendered as an absolute host path; containment validation normally
+prevents this case.
 
 The Action has these outputs:
 
@@ -168,8 +205,11 @@ the only Action-specific remapping of the CLI exit contract.
 `log-level=quiet` writes no individual findings to ordinary logs; `summary`
 writes only the final summary; `diagnostic` writes all rendered diagnostics;
 and `debug` also writes safe diagnostic context. Annotation and summary limits
-are applied independently of log level. The Action must report suppression
-counts rather than silently dropping output.
+are applied independently of log level. For Action log rendering,
+`diagnostic` and `debug` enable the CLI's `--show-skips` presentation, while
+`quiet` and `summary` hide individual skip warnings; all levels preserve the
+skipped count. The Action must report suppression counts rather than silently
+dropping output.
 
 ## Acceptance criteria
 
@@ -183,6 +223,18 @@ counts rather than silently dropping output.
 - The Action validates every input, confines selected paths to the workspace,
   produces the declared outputs, and preserves execution-error failures even
   when `fail-on-violation` is false.
+- With no CLI positional path, selection is identical to selecting `.`; skip
+  warnings are hidden by default and `--show-skips` changes only their
+  presentation.
+- Action `diagnostic` and `debug` logs show skip diagnostics, while `quiet` and
+  `summary` logs hide them; every log level reports the same skipped count.
+- Action path parsing ignores blank lines, treats an empty parsed value as `.`,
+  removes normalized duplicates in first-occurrence order, rejects absolute
+  paths and workspace escapes, and reports contained nonexistent paths as I/O
+  errors.
+- Action tests cover a nested working directory, `..` that remains contained,
+  lexical escapes, symlink escapes, and workspace-relative forward-slash paths
+  in logs, summaries, and annotations.
 - On GitHub Actions, the Action emits correctly escaped, location-aware
   annotations up to `max-annotations`, reports the suppressed count, and writes
   one bounded job summary when enabled.
@@ -218,9 +270,6 @@ tests must be added before declaring either output stable.
   fail instead of skip? The initial release intentionally skips, matching the
   current discovery-oriented model; a future opt-in policy would need a new
   diagnostic code and documentation.
-- Which target-selection and ignore-file semantics will the CLI expose, and how
-  will they distinguish an empty selection from an excluded path? This design
-  fixes their result semantics but not their selection syntax.
 - Should the future JSON format be one complete document, newline-delimited
   JSON records, or support both? The choice affects streaming and schema
   versioning.

--- a/docs/design/cli-diagnostics-and-github-action.md
+++ b/docs/design/cli-diagnostics-and-github-action.md
@@ -40,8 +40,14 @@ individual messages as identifiers.
 Each diagnostic has a severity, category, message, optional path, and optional
 one-based line and column. A finding additionally identifies the checked
 EditorConfig property, expected value, and observed value when those values are
-available. Paths are relative to the invocation working directory whenever
-possible and use forward slashes in rendered output.
+available. CLI paths use the invocation working directory captured at process
+startup as their display base. The first selected spelling is made absolute
+against that base and lexically normalized, but is not canonicalized merely for
+display; it is then rendered relative to the base. This preserves a user's
+direct symbolic-link spelling. If a relative path cannot be represented, such
+as across Windows volumes, the normalized absolute spelling is rendered. Paths
+use forward slashes in all rendered output. Display-path choice never supplies
+file identity or workspace-containment evidence.
 
 The initial text format is intended for terminals and CI logs, not as a
 machine-readable API. One diagnostic is rendered on one line; the location is
@@ -122,9 +128,12 @@ resolves outside `GITHUB_WORKSPACE`.
 
 `GITHUB_WORKSPACE` is the immutable containment and annotation base. The Action
 canonicalizes it first. `working-directory` must be relative (an absolute value
-is rejected), is resolved against that base, and is then canonicalized; it must
-name an existing directory whose resolved location is contained by the
-canonical workspace. The default `.` therefore means the workspace root.
+is rejected), is resolved against that base, and is lexically normalized. Both
+that lexical result and its canonical result must be contained by the canonical
+workspace. It must name an existing directory. Thus a lexical escape is not
+made valid by a symbolic link back into the workspace, and a contained lexical
+path is rejected if symbolic-link resolution escapes. The default `.` means the
+workspace root.
 
 The Action parses `paths` by splitting on lines, removing a trailing carriage
 return, trimming leading and trailing ASCII whitespace from each line, and
@@ -136,15 +145,21 @@ absolute paths are configuration errors.
 
 Each path is resolved against the canonical working directory and lexically
 normalized before filesystem access. A lexical `..` is allowed only when the
-normalized result remains within the workspace. Existing paths are then
-canonicalized to resolve symbolic links and must still be contained by the
-canonical workspace. A nonexistent path that is lexically contained proceeds
-to normal selection and becomes `ECCI-IO`; an escape, including an existing
-symlink that resolves outside the workspace, is `ECCI-CONFIG`. Normalized
-entries are de-duplicated in input order before invoking selection. The
-selection layer performs its own resolved-file identity de-duplication, so
-aliases and direct symbolic links that survive containment are also checked
-only once.
+normalized absolute result remains within the canonical workspace. For an
+existing path, the whole path is canonicalized. For a nonexistent path, the
+Action canonicalizes its longest existing ancestor and lexically appends the
+remaining components. The resulting resolved path must also remain within the
+canonical workspace. This catches an escape through an existing symbolic-link
+ancestor even when the final component does not exist. A contained nonexistent
+path proceeds to normal selection and becomes `ECCI-IO`; either a lexical or
+resolved escape is `ECCI-CONFIG`.
+
+Action input de-duplication uses the lexically normalized absolute path as its
+key, with the platform's normal path-comparison semantics, and retains the
+first entry. It intentionally does not use canonical identity: the selection
+layer performs resolved-file identity de-duplication, so aliases and direct
+symbolic links that survive containment are also checked only once while the
+first input spelling remains available for display.
 
 CLI text paths are relative to the invocation working directory when possible,
 as specified above. In the Action, all log, summary, and annotation paths are
@@ -232,8 +247,13 @@ dropping output.
   removes normalized duplicates in first-occurrence order, rejects absolute
   paths and workspace escapes, and reports contained nonexistent paths as I/O
   errors.
+- CLI display tests prove that paths are based on the startup working
+  directory, use forward slashes, preserve the first direct symbolic-link
+  spelling, and fall back to a normalized absolute path only when a relative
+  spelling cannot be represented.
 - Action tests cover a nested working directory, `..` that remains contained,
-  lexical escapes, symlink escapes, and workspace-relative forward-slash paths
+  lexical escapes, symlink escapes, a nonexistent leaf below a symlink escape,
+  duplicate normalized spellings, and workspace-relative forward-slash paths
   in logs, summaries, and annotations.
 - On GitHub Actions, the Action emits correctly escaped, location-aware
   annotations up to `max-annotations`, reports the suppressed count, and writes

--- a/docs/design/cli-file-selection.md
+++ b/docs/design/cli-file-selection.md
@@ -17,6 +17,12 @@ status; this document supplies the selection outcomes that it reports.
 
 ### Inputs and traversal
 
+When no positional path is supplied, the CLI behaves as if one positional
+argument, `.`, had been supplied. The invocation working directory is therefore
+the default traversal root. This is a syntactic default, not a direct-file
+override: all files discovered below `.` still follow the normal ignore and
+binary-selection rules.
+
 Each positional argument is classified independently.
 
 - A directly specified regular file is a direct file.
@@ -33,9 +39,19 @@ or directories. Such entries are skipped with the `symlink` reason. This
 avoids cycles, duplicate checks, and unexpectedly leaving the requested tree.
 
 The implementation must retain enough identity information to check a file at
-most once when the same file is supplied by more than one argument. A direct
-file remains direct for this purpose even if it was already discovered through
-a directory argument.
+most once when the same file is supplied by more than one argument. Identity is
+the resolved regular file, not the spelling of the input path. On platforms
+that expose a stable filesystem object identifier, use that identifier (for
+example, device and inode on Unix); otherwise use a canonical absolute path
+with the platform's normal path comparison semantics. Consequently, a direct
+symbolic link and its target, two direct symbolic links to the same target, and
+a direct path also found through traversal produce one checked-file record.
+
+Directness is merged independently of identity. If any occurrence is a direct
+file, the merged candidate has direct-file semantics and bypasses ignore
+exclusion, even when a traversal occurrence was discovered first. The first
+occurrence in argument and traversal order supplies the display path; merging a
+later direct occurrence changes selection policy but not display spelling.
 
 ### Ignore rules and selection order
 
@@ -55,6 +71,19 @@ also prevents binary-file exclusion. The `.ecciignore` file itself is never
 checked. `.ecciignore` is the only explicit project-level include/exclude
 mechanism; the CLI does not provide `--include` or `--exclude` options.
 
+Ignore matching is a selection-policy API, not an incidental boolean returned
+by the directory walker. For every discovered regular-file candidate, that API
+must return a structured record containing the final applicable `.gitignore`
+match, the final applicable `.ecciignore` match, and the effective decision.
+Each recorded match distinguishes no match, ignore, and whitelist, and records
+the source ignore-file path and rule location when the matching library exposes
+them. The effective record also contains `excluded_by` (`gitignore`,
+`ecciignore`, or none) and `force_check`, which is true only for a final
+`.ecciignore` whitelist match. This record crosses the boundary from discovery
+into selection and reporting; callers must not reconstruct it from whether the
+walker yielded a path. Directory pruning may use the same matcher, but must not
+replace this per-candidate record.
+
 For a discovered file, selection proceeds in this order:
 
 1. Skip symbolic links.
@@ -65,8 +94,9 @@ For a discovered file, selection proceeds in this order:
 4. Resolve the file's applicable `.editorconfig` configuration.
 5. Skip the file when no `.editorconfig` applies; otherwise, classify its
    content according to [Binary-file detection](binary-file-detection.md).
-6. Skip a binary file unless a final negated `.ecciignore` rule force-selects
-   it; submit the remaining file to the checker.
+6. Record the classifier result. Skip a binary file unless the ignore-decision
+   record has `force_check=true`; in that case submit it to the checker despite
+   the `Binary` result. Submit text files normally.
 
 A direct file bypasses both ignore mechanisms and is submitted to
 EditorConfig resolution even if `.gitignore` or `.ecciignore` would exclude
@@ -103,6 +133,12 @@ intentional skips to `ECCI-SKIP` diagnostics when skips are shown and maps
 operational errors to `ECCI-IO`. It defines the human-readable text format,
 summary, and future machine-readable formats.
 
+Skip diagnostics are hidden in normal CLI output by default, while every skip
+is still retained in the typed report and included in the aggregate skipped
+count. `--show-skips` emits one `ECCI-SKIP` warning per retained skip. This flag
+changes presentation only; it does not change selection, counts, or exit
+status. There is no negative form because hidden is the default.
+
 ### Exit status
 
 The selection layer records its outcomes and does not assign an aggregate exit
@@ -134,15 +170,17 @@ covered by automated CLI or selection-layer tests.
 | `.gitignore` | Root and nested files apply relative patterns; a nested rule overrides a parent rule; `.git/info/exclude` and global excludes do not affect results. |
 | `.ecciignore` | Root and nested files apply hierarchically; its rules take precedence over `.gitignore`; a final negated rule re-includes a regular file and force-selects it for binary detection. |
 | Direct paths | A direct ignored regular file is selected; a direct directory honors ignore files; missing, unsupported, and broken-link paths are operational errors while later arguments continue. |
-| Filesystem traversal | Hidden files are candidates; traversal skips file and directory symlinks; a direct symlink to a regular file is checked; duplicate inputs do not produce duplicate checks. |
+| Defaults and traversal | Omitting positional paths behaves exactly like a single `.` directory argument; hidden files are candidates; traversal skips file and directory symlinks. |
+| File identity | A target named directly, through one or more direct symlinks, and through traversal is checked once; any direct occurrence gives the merged candidate direct-file semantics, while the first occurrence supplies its display path. |
 | EditorConfig and binary detection | A file with applicable configuration reaches binary detection and then the checker; a file with no applicable `.editorconfig` is skipped with the correct reason; binary selection follows the binary-file design. |
-| Reporting | Every skip and error has its required reason category and path; errors contain operation detail for presentation by the output layer. |
+| Ignore decision API | Tests cover parent and nested rules, ignore followed by whitelist and whitelist followed by ignore, and disagreement between `.gitignore` and `.ecciignore`; the structured result records both final source matches, the effective exclusion, and `force_check` before binary classification. |
+| Reporting | Every skip and error has its required reason category and path; errors contain operation detail for presentation by the output layer; skips are counted but hidden by default and `--show-skips` renders them without changing status or counts. |
 | Exit status | Test selection errors through the shared contract: CLI configuration error `2`, I/O error `3`, violation `1`, and intentional skips `0`; execution errors take precedence over violations. |
 
 ## Unresolved related work
 
 The [CLI diagnostics and GitHub Action](cli-diagnostics-and-github-action.md)
-design defers JSON/SARIF schemas and skip-presentation defaults. Those choices
+design defers JSON/SARIF schemas. Those choices
 must preserve the selection reason categories and error details required by
 this document. No other file-selection behavior is intentionally left
 undecided.


### PR DESCRIPTION
## Summary

- define default CLI path and skip-diagnostic presentation
- specify GitHub Action path parsing, normalization, containment, and display bases
- define resolved-file identity and the structured final ignore-match API boundary
- align binary classification order with file selection and add acceptance criteria

## Verification

- `git diff --check`
- Rust tests not run because this change only updates design documentation