### PR TITLE
Add shared typed report model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,10 @@ name = "ecci-editorconfig"
 version = "0.0.0"
 
 [[package]]
+name = "ecci-report"
+version = "0.0.0"
+
+[[package]]
 name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
 
-members = ["crates/ecci", "crates/ecci-checker", "crates/ecci-editorconfig"]
+members = [
+    "crates/ecci",
+    "crates/ecci-checker",
+    "crates/ecci-editorconfig",
+    "crates/ecci-report",
+]
 
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [workspace]
 
 members = [
-    "crates/ecci",
-    "crates/ecci-checker",
-    "crates/ecci-editorconfig",
-    "crates/ecci-report",
+  "crates/ecci",
+  "crates/ecci-checker",
+  "crates/ecci-editorconfig",
+  "crates/ecci-report",
 ]
 
 resolver = "2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,11 @@ COPY Cargo.toml Cargo.lock ./
 COPY crates/ecci/Cargo.toml crates/ecci/Cargo.toml
 COPY crates/ecci-checker/Cargo.toml crates/ecci-checker/Cargo.toml
 COPY crates/ecci-editorconfig/Cargo.toml crates/ecci-editorconfig/Cargo.toml
+COPY crates/ecci-report/Cargo.toml crates/ecci-report/Cargo.toml
 # Cargo validates every workspace member before fetching. These placeholder
 # targets make the manifest-only workspace valid without copying real sources.
-RUN mkdir -p crates/ecci/src crates/ecci-checker/src crates/ecci-editorconfig/src \
-    && touch crates/ecci/src/main.rs crates/ecci-checker/src/lib.rs crates/ecci-editorconfig/src/lib.rs
+RUN mkdir -p crates/ecci/src crates/ecci-checker/src crates/ecci-editorconfig/src crates/ecci-report/src \
+    && touch crates/ecci/src/main.rs crates/ecci-checker/src/lib.rs crates/ecci-editorconfig/src/lib.rs crates/ecci-report/src/lib.rs
 RUN cargo fetch --locked
 
 COPY crates ./crates

--- a/crates/ecci-report/Cargo.toml
+++ b/crates/ecci-report/Cargo.toml
@@ -2,4 +2,3 @@
 name = "ecci-report"
 version = "0.0.0"
 edition = "2021"
-

--- a/crates/ecci-report/Cargo.toml
+++ b/crates/ecci-report/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "ecci-report"
+version = "0.0.0"
+edition = "2021"
+

--- a/crates/ecci-report/src/lib.rs
+++ b/crates/ecci-report/src/lib.rs
@@ -1,0 +1,398 @@
+//! Typed results shared by ecci front ends.
+//!
+//! Renderers consume [`Report`] directly. Rendered diagnostic text is a human
+//! interface and must not be parsed to recover report data.
+
+use std::fmt::{self, Write};
+use std::num::NonZeroUsize;
+use std::path::PathBuf;
+
+/// A stable, renderer-independent diagnostic identifier.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum DiagnosticCode {
+    Finding(String),
+    Skip,
+    Configuration,
+    Io,
+    Internal,
+}
+
+impl DiagnosticCode {
+    pub fn finding(code: impl Into<String>) -> Self {
+        Self::Finding(code.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Finding(code) => code,
+            Self::Skip => "ECCI-SKIP",
+            Self::Configuration => "ECCI-CONFIG",
+            Self::Io => "ECCI-IO",
+            Self::Internal => "ECCI-INTERNAL",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Category {
+    Finding,
+    IntentionalSkip,
+    ConfigurationError,
+    IoError,
+    InternalError,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Severity {
+    Warning,
+    Error,
+}
+
+/// An optional path and one-based source position.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Location {
+    pub path: Option<PathBuf>,
+    pub line: Option<NonZeroUsize>,
+    pub column: Option<NonZeroUsize>,
+}
+
+impl Location {
+    pub fn path(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: Some(path.into()),
+            ..Self::default()
+        }
+    }
+
+    pub fn at(path: impl Into<PathBuf>, line: NonZeroUsize, column: NonZeroUsize) -> Self {
+        Self {
+            path: Some(path.into()),
+            line: Some(line),
+            column: Some(column),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Finding {
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub location: Option<Location>,
+    pub property: String,
+    pub expected: Option<String>,
+    pub observed: Option<String>,
+}
+
+impl Finding {
+    pub fn new(
+        code: impl Into<String>,
+        property: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            code: DiagnosticCode::finding(code),
+            message: message.into(),
+            location: None,
+            property: property.into(),
+            expected: None,
+            observed: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IntentionalSkip {
+    pub message: String,
+    pub location: Option<Location>,
+}
+
+/// Debug-only causal text which the producer has explicitly classified as safe.
+///
+/// Producers must remove secrets, environment values, target-file content,
+/// backtraces, and host-specific absolute paths before constructing this type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SafeDebugDetail(String);
+
+impl SafeDebugDetail {
+    pub fn from_sanitized(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExecutionErrorKind {
+    Configuration,
+    Io,
+    Internal,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExecutionError {
+    pub kind: ExecutionErrorKind,
+    pub message: String,
+    pub location: Option<Location>,
+    debug_details: Vec<SafeDebugDetail>,
+}
+
+impl ExecutionError {
+    pub fn new(kind: ExecutionErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            location: None,
+            debug_details: Vec::new(),
+        }
+    }
+
+    pub fn with_safe_debug_detail(mut self, detail: SafeDebugDetail) -> Self {
+        self.debug_details.push(detail);
+        self
+    }
+
+    pub fn debug_details(&self) -> &[SafeDebugDetail] {
+        &self.debug_details
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Diagnostic {
+    Finding(Finding),
+    IntentionalSkip(IntentionalSkip),
+    ExecutionError(ExecutionError),
+}
+
+impl Diagnostic {
+    pub fn code(&self) -> &DiagnosticCode {
+        match self {
+            Self::Finding(finding) => &finding.code,
+            Self::IntentionalSkip(_) => &DiagnosticCode::Skip,
+            Self::ExecutionError(error) => match error.kind {
+                ExecutionErrorKind::Configuration => &DiagnosticCode::Configuration,
+                ExecutionErrorKind::Io => &DiagnosticCode::Io,
+                ExecutionErrorKind::Internal => &DiagnosticCode::Internal,
+            },
+        }
+    }
+
+    pub fn category(&self) -> Category {
+        match self {
+            Self::Finding(_) => Category::Finding,
+            Self::IntentionalSkip(_) => Category::IntentionalSkip,
+            Self::ExecutionError(error) => match error.kind {
+                ExecutionErrorKind::Configuration => Category::ConfigurationError,
+                ExecutionErrorKind::Io => Category::IoError,
+                ExecutionErrorKind::Internal => Category::InternalError,
+            },
+        }
+    }
+
+    pub fn severity(&self) -> Severity {
+        match self {
+            Self::IntentionalSkip(_) => Severity::Warning,
+            Self::Finding(_) | Self::ExecutionError(_) => Severity::Error,
+        }
+    }
+
+    pub fn location(&self) -> Option<&Location> {
+        match self {
+            Self::Finding(value) => value.location.as_ref(),
+            Self::IntentionalSkip(value) => value.location.as_ref(),
+            Self::ExecutionError(value) => value.location.as_ref(),
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        match self {
+            Self::Finding(value) => &value.message,
+            Self::IntentionalSkip(value) => &value.message,
+            Self::ExecutionError(value) => &value.message,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Counters {
+    pub checked_files: usize,
+    pub violations: usize,
+    pub skipped_files: usize,
+    pub execution_errors: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(i32)]
+pub enum ExitStatus {
+    Success = 0,
+    Violations = 1,
+    ConfigurationError = 2,
+    IoError = 3,
+    InternalError = 4,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Report {
+    checked_files: usize,
+    diagnostics: Vec<Diagnostic>,
+}
+
+impl Report {
+    pub fn record_checked_file(&mut self) {
+        self.checked_files += 1;
+    }
+
+    pub fn push(&mut self, diagnostic: Diagnostic) {
+        if matches!(
+            diagnostic,
+            Diagnostic::ExecutionError(ExecutionError {
+                kind: ExecutionErrorKind::Internal,
+                ..
+            })
+        ) && self.diagnostics.iter().any(|existing| {
+            matches!(
+                existing,
+                Diagnostic::ExecutionError(ExecutionError {
+                    kind: ExecutionErrorKind::Internal,
+                    ..
+                })
+            )
+        }) {
+            return;
+        }
+        self.diagnostics.push(diagnostic);
+    }
+
+    pub fn diagnostics(&self) -> &[Diagnostic] {
+        &self.diagnostics
+    }
+
+    pub fn counters(&self) -> Counters {
+        let mut counters = Counters {
+            checked_files: self.checked_files,
+            ..Counters::default()
+        };
+        for diagnostic in &self.diagnostics {
+            match diagnostic {
+                Diagnostic::Finding(_) => counters.violations += 1,
+                Diagnostic::IntentionalSkip(_) => counters.skipped_files += 1,
+                Diagnostic::ExecutionError(_) => counters.execution_errors += 1,
+            }
+        }
+        counters
+    }
+
+    /// Computes the invocation result using internal > configuration > I/O >
+    /// findings precedence. This deliberately does not use numeric maximum.
+    pub fn exit_status(&self) -> ExitStatus {
+        let mut has_finding = false;
+        let mut has_io_error = false;
+        let mut has_configuration_error = false;
+        for diagnostic in &self.diagnostics {
+            match diagnostic {
+                Diagnostic::Finding(_) => has_finding = true,
+                Diagnostic::ExecutionError(error) => match error.kind {
+                    ExecutionErrorKind::Internal => return ExitStatus::InternalError,
+                    ExecutionErrorKind::Configuration => has_configuration_error = true,
+                    ExecutionErrorKind::Io => has_io_error = true,
+                },
+                Diagnostic::IntentionalSkip(_) => {}
+            }
+        }
+        if has_configuration_error {
+            ExitStatus::ConfigurationError
+        } else if has_io_error {
+            ExitStatus::IoError
+        } else if has_finding {
+            ExitStatus::Violations
+        } else {
+            ExitStatus::Success
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TextRenderOptions {
+    pub show_skips: bool,
+    pub debug: bool,
+}
+
+pub fn render_text(report: &Report, options: TextRenderOptions) -> String {
+    let mut output = String::new();
+    for diagnostic in report.diagnostics() {
+        if matches!(diagnostic, Diagnostic::IntentionalSkip(_)) && !options.show_skips {
+            continue;
+        }
+        render_diagnostic(&mut output, diagnostic);
+        if options.debug {
+            if let Diagnostic::ExecutionError(error) = diagnostic {
+                for detail in error.debug_details() {
+                    let _ = writeln!(
+                        output,
+                        "  debug: caused by: {}",
+                        single_line(detail.as_str())
+                    );
+                }
+            }
+        }
+    }
+    let _ = writeln!(output, "{}", render_summary(report));
+    output
+}
+
+pub fn render_summary(report: &Report) -> String {
+    let counters = report.counters();
+    if counters.checked_files == 0
+        && counters.violations == 0
+        && counters.skipped_files == 0
+        && counters.execution_errors == 0
+    {
+        return "Checked 0 files: no targets selected.".to_owned();
+    }
+    format!(
+        "Checked {} files: {} violations, {} skipped, {} execution errors.",
+        counters.checked_files,
+        counters.violations,
+        counters.skipped_files,
+        counters.execution_errors
+    )
+}
+
+fn render_diagnostic(output: &mut String, diagnostic: &Diagnostic) {
+    let severity = match diagnostic.severity() {
+        Severity::Warning => "warning",
+        Severity::Error => "error",
+    };
+    let _ = write!(output, "{severity}[{}]", diagnostic.code().as_str());
+    if let Some(location) = diagnostic.location() {
+        render_location(output, location);
+    }
+    let _ = writeln!(output, ": {}", single_line(diagnostic.message()));
+}
+
+fn render_location(output: &mut String, location: &Location) {
+    if let Some(path) = &location.path {
+        let rendered = path.to_string_lossy().replace('\\', "/");
+        let _ = write!(output, " {}", single_line(&rendered));
+    }
+    if let Some(line) = location.line {
+        let _ = write!(output, ":{line}");
+        if let Some(column) = location.column {
+            let _ = write!(output, ":{column}");
+        }
+    }
+}
+
+fn single_line(value: &str) -> String {
+    value.replace(['\r', '\n'], " ")
+}
+
+impl fmt::Display for ExitStatus {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", *self as i32)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/ecci-report/src/tests.rs
+++ b/crates/ecci-report/src/tests.rs
@@ -1,0 +1,174 @@
+use super::*;
+
+fn nonzero(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).unwrap()
+}
+
+fn finding() -> Diagnostic {
+    let mut finding = Finding::new(
+        "ECCI001",
+        "indent_style",
+        "indent_style must be space; found tab",
+    );
+    finding.expected = Some("space".into());
+    finding.observed = Some("tab".into());
+    finding.location = Some(Location::at("src\\lib.rs", nonzero(14), nonzero(1)));
+    Diagnostic::Finding(finding)
+}
+
+fn execution_error(kind: ExecutionErrorKind) -> Diagnostic {
+    Diagnostic::ExecutionError(ExecutionError::new(kind, "could not complete check"))
+}
+
+#[test]
+fn exposes_stable_codes_categories_and_finding_values() {
+    let finding = finding();
+    assert_eq!(finding.code().as_str(), "ECCI001");
+    assert_eq!(finding.category(), Category::Finding);
+    let skip = Diagnostic::IntentionalSkip(IntentionalSkip {
+        message: "no .editorconfig applies; skipped".into(),
+        location: None,
+    });
+    assert_eq!(skip.code().as_str(), "ECCI-SKIP");
+    assert_eq!(skip.category(), Category::IntentionalSkip);
+
+    for (kind, code, category) in [
+        (
+            ExecutionErrorKind::Configuration,
+            "ECCI-CONFIG",
+            Category::ConfigurationError,
+        ),
+        (ExecutionErrorKind::Io, "ECCI-IO", Category::IoError),
+        (
+            ExecutionErrorKind::Internal,
+            "ECCI-INTERNAL",
+            Category::InternalError,
+        ),
+    ] {
+        let diagnostic = execution_error(kind);
+        assert_eq!(diagnostic.code().as_str(), code);
+        assert_eq!(diagnostic.category(), category);
+    }
+}
+
+#[test]
+fn renders_diagnostics_with_and_without_locations() {
+    let mut report = Report::default();
+    report.record_checked_file();
+    report.push(finding());
+    report.push(execution_error(ExecutionErrorKind::Internal));
+
+    assert_eq!(
+        render_text(&report, TextRenderOptions::default()),
+        concat!(
+            "error[ECCI001] src/lib.rs:14:1: indent_style must be space; found tab\n",
+            "error[ECCI-INTERNAL]: could not complete check\n",
+            "Checked 1 files: 1 violations, 0 skipped, 1 execution errors.\n"
+        )
+    );
+}
+
+#[test]
+fn summary_distinguishes_no_targets_and_aggregates_mixed_results() {
+    assert_eq!(
+        render_summary(&Report::default()),
+        "Checked 0 files: no targets selected."
+    );
+
+    let mut report = Report::default();
+    report.record_checked_file();
+    report.record_checked_file();
+    report.push(finding());
+    report.push(Diagnostic::IntentionalSkip(IntentionalSkip {
+        message: "no .editorconfig applies; skipped".into(),
+        location: Some(Location::path("README.md")),
+    }));
+    report.push(execution_error(ExecutionErrorKind::Io));
+    assert_eq!(
+        report.counters(),
+        Counters {
+            checked_files: 2,
+            violations: 1,
+            skipped_files: 1,
+            execution_errors: 1,
+        }
+    );
+    assert_eq!(
+        render_summary(&report),
+        "Checked 2 files: 1 violations, 1 skipped, 1 execution errors."
+    );
+}
+
+#[test]
+fn exit_status_covers_zero_through_four_and_required_precedence() {
+    assert_eq!(Report::default().exit_status(), ExitStatus::Success);
+
+    let mut report = Report::default();
+    report.push(finding());
+    assert_eq!(report.exit_status(), ExitStatus::Violations);
+    report.push(execution_error(ExecutionErrorKind::Io));
+    assert_eq!(report.exit_status(), ExitStatus::IoError);
+    report.push(execution_error(ExecutionErrorKind::Configuration));
+    assert_eq!(report.exit_status(), ExitStatus::ConfigurationError);
+    report.push(execution_error(ExecutionErrorKind::Internal));
+    assert_eq!(report.exit_status(), ExitStatus::InternalError);
+
+    assert_eq!(ExitStatus::Success as i32, 0);
+    assert_eq!(ExitStatus::Violations as i32, 1);
+    assert_eq!(ExitStatus::ConfigurationError as i32, 2);
+    assert_eq!(ExitStatus::IoError as i32, 3);
+    assert_eq!(ExitStatus::InternalError as i32, 4);
+}
+
+#[test]
+fn debug_details_require_opt_in_and_do_not_change_normal_diagnostic() {
+    let error = ExecutionError::new(ExecutionErrorKind::Io, "failed to read file")
+        .with_safe_debug_detail(SafeDebugDetail::from_sanitized(
+            "read returned permission denied",
+        ));
+    let mut report = Report::default();
+    report.push(Diagnostic::ExecutionError(error));
+
+    let normal = render_text(&report, TextRenderOptions::default());
+    assert!(!normal.contains("permission denied"));
+    assert_eq!(report.exit_status(), ExitStatus::IoError);
+
+    let debug = render_text(
+        &report,
+        TextRenderOptions {
+            debug: true,
+            ..TextRenderOptions::default()
+        },
+    );
+    assert!(debug.contains("  debug: caused by: read returned permission denied\n"));
+    assert_eq!(report.exit_status(), ExitStatus::IoError);
+}
+
+#[test]
+fn renderer_keeps_each_diagnostic_and_debug_cause_on_one_line() {
+    let error = ExecutionError::new(ExecutionErrorKind::Io, "failed\nto read")
+        .with_safe_debug_detail(SafeDebugDetail::from_sanitized("first\r\nsecond"));
+    let mut report = Report::default();
+    report.push(Diagnostic::ExecutionError(error));
+
+    let rendered = render_text(
+        &report,
+        TextRenderOptions {
+            debug: true,
+            ..TextRenderOptions::default()
+        },
+    );
+    assert!(
+        rendered.starts_with("error[ECCI-IO]: failed to read\n  debug: caused by: first  second\n")
+    );
+}
+
+#[test]
+fn report_keeps_exactly_one_internal_error() {
+    let mut report = Report::default();
+    report.push(execution_error(ExecutionErrorKind::Internal));
+    report.push(execution_error(ExecutionErrorKind::Internal));
+
+    assert_eq!(report.counters().execution_errors, 1);
+    assert_eq!(report.diagnostics().len(), 1);
+}

--- a/docs/design/cli-diagnostics-and-github-action.md
+++ b/docs/design/cli-diagnostics-and-github-action.md
@@ -2,10 +2,12 @@
 
 ## Status and scope
 
-This document defines the intended public result-reporting contract for the
-first stable `ecci` command-line interface (CLI) and its GitHub Action. It is a
-design decision, not a description of the current CLI prototype. User-facing
-usage documentation will be added when the contract is implemented.
+This document defines the public result-reporting contract for the first stable
+`ecci` command-line interface (CLI) and its GitHub Action. The shared in-memory
+model and text renderer are implemented in `ecci-report`; wiring the model into
+target selection, checker execution, the CLI, and the Action remains separate
+work. The examples below therefore define required behavior and are not a
+claim that the current CLI prototype exposes it yet.
 
 The design distinguishes a **finding** (a checked file does not conform) from
 an **execution error** (the command could not reliably complete the requested
@@ -34,6 +36,14 @@ selected, versioned format (for example, `--format json` with a top-level
 `schema_version`); it is not implied by the text format. SARIF is an export of
 the same report model and must use stable rule identifiers rather than treating
 individual messages as identifiers.
+
+The `ecci-report` crate owns this presentation-independent model. It represents
+findings, intentional skips, the three execution-error categories, optional
+paths and one-based locations, property and expected/observed values, stable
+codes, counters, and the invocation exit status. CLI text, Action annotations,
+job summaries, and future structured formats consume the same typed report.
+Counters are derived from report entries so renderers cannot disagree about
+aggregate results.
 
 ## Diagnostic model and text output
 
@@ -75,6 +85,11 @@ The following cases have these required meanings and text examples:
 
 `--debug` may add causal-chain details for execution errors to stderr, but it
 must not change the category, exit code, or the normal diagnostic message.
+The model accepts debug causes only through the explicitly named
+`SafeDebugDetail::from_sanitized` boundary. Producers must remove secrets,
+environment values, target-file content, backtraces, and host-specific absolute
+paths before crossing that boundary. Normal rendering never reads these
+details; debug rendering opts in explicitly and keeps every cause on one line.
 
 ## Exit-status contract
 

--- a/docs/user/cli.md
+++ b/docs/user/cli.md
@@ -56,6 +56,13 @@ There is no stable CLI result-reporting or exit-status contract for
 configuration violations. Do not use the current command in continuous
 integration to determine whether files conform.
 
+The underlying typed report model and human-oriented text renderer now
+implement the agreed diagnostic categories, aggregate summary, and exit-status
+calculation. They are not connected to the current CLI prototype yet. Once the
+checker execution path is connected, diagnostics will be human-facing output,
+not a machine-readable interface; integrations such as the GitHub Action will
+consume the typed report directly instead of parsing CLI text.
+
 ## Roadmap
 
 The planned end-user-facing work is:


### PR DESCRIPTION
## Summary

- add a typed in-memory report model shared by CLI and GitHub Action renderers
- represent findings, intentional skips, execution errors, locations, values, counters, and exit-status precedence
- render human diagnostics and final summaries with opt-in sanitized debug causes
- document the implemented reporting layer and add focused unit tests

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace` (85 passed, 4 ignored)
- `cargo clippy -p ecci-report --all-targets -- -D warnings`
- `git diff --check`

Workspace-wide Clippy remains blocked by the pre-existing `manual_is_multiple_of` warning in `crates/ecci-checker/src/charset.rs`.