### PR TITLE
Implement the Docker GitHub Action contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ CLI documentation for options and the complete exit-status contract.
 
 - [CLI usage, configuration, and checks](docs/user/cli.md)
 - [`.ecciignore` configuration](docs/user/ecciignore.md)
+- [GitHub Action usage](docs/user/github-action.md)
 - [Development and testing](docs/development/README.md)
 - [Technical design documentation](docs/design/README.md)
 - [Documentation governance](docs/design/documentation-governance.md)

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,43 @@
 name: 'ecci'
-desctiption: 'Check .editorconfig settings is applied'
+description: 'Check files against their applicable .editorconfig settings'
+inputs:
+  paths:
+    description: 'Newline-separated repository-relative files or directories to check'
+    required: false
+    default: '.'
+  working-directory:
+    description: 'Directory, within the workspace, used to resolve paths'
+    required: false
+    default: '.'
+  fail-on-violation:
+    description: 'Fail the action when violations are found'
+    required: false
+    default: 'true'
+  annotations:
+    description: 'Emit GitHub workflow-command annotations'
+    required: false
+    default: 'true'
+  summary:
+    description: 'Write a GitHub Actions job summary'
+    required: false
+    default: 'true'
+  max-annotations:
+    description: 'Maximum number of file-level annotations'
+    required: false
+    default: '50'
+  log-level:
+    description: 'Log volume: quiet, summary, diagnostic, or debug'
+    required: false
+    default: 'summary'
+outputs:
+  outcome:
+    description: 'success, violations, configuration-error, io-error, or internal-error'
+  violations:
+    description: 'Number of reported violations'
+  checked-files:
+    description: 'Number of files fully checked'
+  skipped-files:
+    description: 'Number of intentionally skipped files'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/crates/ecci/src/action.rs
+++ b/crates/ecci/src/action.rs
@@ -1,0 +1,317 @@
+use ecci_report::{render_summary, Diagnostic, ExitStatus, Report, TextRenderOptions};
+use std::env;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+
+const SUMMARY_DIAGNOSTIC_LIMIT: usize = 20;
+const SUMMARY_BYTE_LIMIT: usize = 64 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LogLevel {
+    Quiet,
+    Summary,
+    Diagnostic,
+    Debug,
+}
+
+pub struct ActionOptions {
+    pub paths: Vec<PathBuf>,
+    pub fail_on_violation: bool,
+    pub annotations: bool,
+    pub summary: bool,
+    pub max_annotations: usize,
+    pub log_level: LogLevel,
+}
+
+impl ActionOptions {
+    pub fn from_env() -> Result<Self, String> {
+        let workspace = canonical_dir(
+            "GITHUB_WORKSPACE",
+            env::var_os("GITHUB_WORKSPACE").ok_or("GITHUB_WORKSPACE is required")?,
+        )?;
+        let working_value =
+            env::var_os("INPUT_WORKING_DIRECTORY").ok_or("working-directory is required")?;
+        let working = resolve_confined_dir(&workspace, Path::new(&working_value))?;
+        env::set_current_dir(&working)
+            .map_err(|_| "failed to enter working-directory".to_owned())?;
+        let raw_paths =
+            env::var("INPUT_PATHS").map_err(|_| "paths must be valid UTF-8".to_owned())?;
+        let mut paths = Vec::new();
+        for line in raw_paths.lines() {
+            let value = line.strip_suffix('\r').unwrap_or(line);
+            if value.is_empty() {
+                return Err("paths must not contain empty lines".into());
+            }
+            let path = Path::new(value);
+            if path.is_absolute() {
+                return Err(format!("path {value:?} must be repository-relative"));
+            }
+            ensure_lexically_confined(&working, path, &workspace)?;
+            let joined = working.join(path);
+            if !canonical_existing_ancestor(&joined).starts_with(&workspace) {
+                return Err(format!("path {value:?} resolves outside GITHUB_WORKSPACE"));
+            }
+            paths.push(path.to_owned());
+        }
+        if paths.is_empty() {
+            return Err("paths must contain at least one non-empty line".into());
+        }
+        Ok(Self {
+            paths,
+            fail_on_violation: boolean("INPUT_FAIL_ON_VIOLATION")?,
+            annotations: boolean("INPUT_ANNOTATIONS")?,
+            summary: boolean("INPUT_SUMMARY")?,
+            max_annotations: env::var("INPUT_MAX_ANNOTATIONS")
+                .map_err(|_| "max-annotations is required")?
+                .parse()
+                .map_err(|_| "max-annotations must be a non-negative decimal integer".to_owned())?,
+            log_level: match env::var("INPUT_LOG_LEVEL").as_deref() {
+                Ok("quiet") => LogLevel::Quiet,
+                Ok("summary") => LogLevel::Summary,
+                Ok("diagnostic") => LogLevel::Diagnostic,
+                Ok("debug") => LogLevel::Debug,
+                _ => return Err("log-level must be quiet, summary, diagnostic, or debug".into()),
+            },
+        })
+    }
+}
+
+fn canonical_existing_ancestor(path: &Path) -> PathBuf {
+    let mut candidate = path;
+    loop {
+        if let Ok(canonical) = candidate.canonicalize() {
+            return canonical;
+        }
+        candidate = candidate
+            .parent()
+            .expect("an absolute path has an existing ancestor");
+    }
+}
+
+fn boolean(name: &str) -> Result<bool, String> {
+    match env::var(name).as_deref() {
+        Ok("true") => Ok(true),
+        Ok("false") => Ok(false),
+        _ => Err(format!(
+            "{} must be exactly true or false",
+            name.trim_start_matches("INPUT_")
+                .to_ascii_lowercase()
+                .replace('_', "-")
+        )),
+    }
+}
+
+fn canonical_dir(name: &str, value: std::ffi::OsString) -> Result<PathBuf, String> {
+    PathBuf::from(value)
+        .canonicalize()
+        .map_err(|_| format!("{name} must name an existing directory"))
+}
+
+fn resolve_confined_dir(workspace: &Path, value: &Path) -> Result<PathBuf, String> {
+    let candidate = if value.is_absolute() {
+        value.to_owned()
+    } else {
+        workspace.join(value)
+    };
+    let canonical = candidate
+        .canonicalize()
+        .map_err(|_| "working-directory must name an existing directory".to_owned())?;
+    if !canonical.starts_with(workspace) {
+        return Err("working-directory resolves outside GITHUB_WORKSPACE".into());
+    }
+    if !canonical.is_dir() {
+        return Err("working-directory must name a directory".into());
+    }
+    Ok(canonical)
+}
+
+fn ensure_lexically_confined(base: &Path, path: &Path, workspace: &Path) -> Result<(), String> {
+    let mut candidate = base.to_path_buf();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(v) => candidate.push(v),
+            Component::ParentDir => {
+                candidate.pop();
+            }
+            _ => return Err("paths must be repository-relative".into()),
+        }
+    }
+    if !candidate.starts_with(workspace) {
+        return Err(format!("path {:?} resolves outside GITHUB_WORKSPACE", path));
+    }
+    Ok(())
+}
+
+pub fn render(report: &Report, options: &ActionOptions) -> i32 {
+    let counters = report.counters();
+    let status = report.exit_status();
+    write_outputs(
+        status,
+        counters.checked_files,
+        counters.violations,
+        counters.skipped_files,
+    );
+    if options.annotations {
+        write_annotations(report, options.max_annotations);
+    }
+    match options.log_level {
+        LogLevel::Quiet => {}
+        LogLevel::Summary => println!("{}", render_summary(report)),
+        LogLevel::Diagnostic | LogLevel::Debug => eprint!(
+            "{}",
+            ecci_report::render_text(
+                report,
+                TextRenderOptions {
+                    show_skips: true,
+                    debug: options.log_level == LogLevel::Debug
+                }
+            )
+        ),
+    }
+    if options.summary {
+        write_summary(report);
+    }
+    if status == ExitStatus::Violations && !options.fail_on_violation {
+        0
+    } else {
+        status as i32
+    }
+}
+
+pub fn render_configuration_error(report: &Report) {
+    let counters = report.counters();
+    write_outputs(
+        report.exit_status(),
+        counters.checked_files,
+        counters.violations,
+        counters.skipped_files,
+    );
+    if env::var("INPUT_ANNOTATIONS").as_deref() != Ok("false") {
+        write_annotations(report, 1);
+    }
+    if env::var("INPUT_SUMMARY").as_deref() != Ok("false") {
+        write_summary(report);
+    }
+}
+
+fn outcome(status: ExitStatus) -> &'static str {
+    match status {
+        ExitStatus::Success => "success",
+        ExitStatus::Violations => "violations",
+        ExitStatus::ConfigurationError => "configuration-error",
+        ExitStatus::IoError => "io-error",
+        ExitStatus::InternalError => "internal-error",
+    }
+}
+
+fn write_outputs(status: ExitStatus, checked: usize, violations: usize, skipped: usize) {
+    let Some(file) = env::var_os("GITHUB_OUTPUT") else {
+        return;
+    };
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(file) {
+        let _ = writeln!(file, "outcome={}", outcome(status));
+        let _ = writeln!(file, "violations={violations}");
+        let _ = writeln!(file, "checked-files={checked}");
+        let _ = writeln!(file, "skipped-files={skipped}");
+    }
+}
+
+fn escape_data(value: &str) -> String {
+    value
+        .replace('%', "%25")
+        .replace('\r', "%0D")
+        .replace('\n', "%0A")
+}
+fn escape_property(value: &str) -> String {
+    escape_data(value).replace(':', "%3A").replace(',', "%2C")
+}
+
+fn write_annotations(report: &Report, limit: usize) {
+    let reportable: Vec<_> = report
+        .diagnostics()
+        .iter()
+        .filter(|d| !matches!(d, Diagnostic::IntentionalSkip(_)))
+        .collect();
+    for diagnostic in reportable.iter().take(limit) {
+        let mut properties = format!("title={}", escape_property(diagnostic.code().as_str()));
+        if let Some(location) = diagnostic.location() {
+            if let Some(path) = &location.path {
+                properties.push_str(&format!(
+                    ",file={}",
+                    escape_property(&path.to_string_lossy().replace('\\', "/"))
+                ));
+            }
+            if let Some(line) = location.line {
+                properties.push_str(&format!(",line={line}"));
+            }
+            if let Some(column) = location.column {
+                properties.push_str(&format!(",col={column}"));
+            }
+        }
+        println!(
+            "::error {properties}::{}",
+            escape_data(diagnostic.message())
+        );
+    }
+    if reportable.len() > limit {
+        println!(
+            "::notice title=ecci::{} annotations suppressed by max-annotations",
+            reportable.len() - limit
+        );
+    }
+}
+
+fn write_summary(report: &Report) {
+    let Some(file) = env::var_os("GITHUB_STEP_SUMMARY") else {
+        return;
+    };
+    let counters = report.counters();
+    let status = report.exit_status();
+    let mut text = format!("## ecci\n\n**Outcome:** {}\n\n| Checked | Violations | Skipped | Execution errors |\n| ---: | ---: | ---: | ---: |\n| {} | {} | {} | {} |\n", outcome(status), counters.checked_files, counters.violations, counters.skipped_files, counters.execution_errors);
+    let findings: Vec<_> = report
+        .diagnostics()
+        .iter()
+        .filter(|d| matches!(d, Diagnostic::Finding(_)))
+        .collect();
+    if !findings.is_empty() {
+        text.push_str("\n### Violations\n\n");
+        for diagnostic in findings.iter().take(SUMMARY_DIAGNOSTIC_LIMIT) {
+            let path = diagnostic
+                .location()
+                .and_then(|l| l.path.as_ref())
+                .map(|p| p.to_string_lossy().replace('\\', "/"))
+                .unwrap_or_else(|| "(unknown location)".into());
+            text.push_str(&format!(
+                "- `{}`: **{}** {}\n",
+                markdown(&path),
+                diagnostic.code().as_str(),
+                markdown(diagnostic.message())
+            ));
+        }
+        if findings.len() > SUMMARY_DIAGNOSTIC_LIMIT {
+            text.push_str(&format!(
+                "\n{} violations omitted.\n",
+                findings.len() - SUMMARY_DIAGNOSTIC_LIMIT
+            ));
+        }
+    }
+    if text.len() > SUMMARY_BYTE_LIMIT {
+        let mut end = SUMMARY_BYTE_LIMIT;
+        while !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        text.truncate(end);
+    }
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(file) {
+        let _ = file.write_all(text.as_bytes());
+    }
+}
+
+fn markdown(value: &str) -> String {
+    value
+        .replace(['\r', '\n'], " ")
+        .replace('`', "\\`")
+        .replace('|', "\\|")
+}

--- a/crates/ecci/src/lib.rs
+++ b/crates/ecci/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod action;
 pub mod binary;
 pub mod selection;

--- a/crates/ecci/src/main.rs
+++ b/crates/ecci/src/main.rs
@@ -12,6 +12,7 @@ struct Options {
     paths: Vec<PathBuf>,
     show_skips: bool,
     debug: bool,
+    github_action: Option<ecci::action::ActionOptions>,
 }
 
 fn main() {
@@ -35,7 +36,9 @@ fn main() {
 }
 
 fn run() -> i32 {
-    let options = match parse_args(std::env::args_os().skip(1)) {
+    let args: Vec<_> = std::env::args_os().skip(1).collect();
+    let action_requested = args.iter().any(|arg| arg == "--github-action");
+    let options = match parse_args(args.into_iter()) {
         Ok(options) => options,
         Err(message) => {
             let mut report = Report::default();
@@ -43,7 +46,11 @@ fn run() -> i32 {
                 ExecutionErrorKind::Configuration,
                 message,
             )));
-            write_report(&report, TextRenderOptions::default());
+            if action_requested {
+                ecci::action::render_configuration_error(&report);
+            } else {
+                write_report(&report, TextRenderOptions::default());
+            }
             return report.exit_status() as i32;
         }
     };
@@ -94,14 +101,18 @@ fn run() -> i32 {
             }
         }
     }
-    write_report(
-        &report,
-        TextRenderOptions {
-            show_skips: options.show_skips,
-            debug: options.debug,
-        },
-    );
-    report.exit_status() as i32
+    if let Some(action) = &options.github_action {
+        ecci::action::render(&report, action)
+    } else {
+        write_report(
+            &report,
+            TextRenderOptions {
+                show_skips: options.show_skips,
+                debug: options.debug,
+            },
+        );
+        report.exit_status() as i32
+    }
 }
 
 fn parse_args(args: impl Iterator<Item = OsString>) -> Result<Options, String> {
@@ -110,6 +121,13 @@ fn parse_args(args: impl Iterator<Item = OsString>) -> Result<Options, String> {
     for arg in args {
         if !positional_only && arg == "--" {
             positional_only = true;
+        } else if !positional_only && arg == "--github-action" {
+            if options.github_action.is_some() {
+                return Err("option --github-action may be specified only once".into());
+            }
+            let action = ecci::action::ActionOptions::from_env()?;
+            options.paths = action.paths.clone();
+            options.github_action = Some(action);
         } else if !positional_only && arg == "--show-skips" {
             if std::mem::replace(&mut options.show_skips, true) {
                 return Err("option --show-skips may be specified only once".into());

--- a/crates/ecci/tests/action.rs
+++ b/crates/ecci/tests/action.rs
@@ -1,0 +1,180 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+fn write(path: &Path, contents: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, contents).unwrap();
+}
+
+struct ActionFixture {
+    temp: TempDir,
+    workspace: PathBuf,
+    output: PathBuf,
+    summary: PathBuf,
+}
+
+impl ActionFixture {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+        fs::create_dir(&workspace).unwrap();
+        Self {
+            output: temp.path().join("output"),
+            summary: temp.path().join("summary"),
+            temp,
+            workspace,
+        }
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_ecci"));
+        command
+            .arg("--github-action")
+            .env("GITHUB_WORKSPACE", &self.workspace)
+            .env("GITHUB_OUTPUT", &self.output)
+            .env("GITHUB_STEP_SUMMARY", &self.summary)
+            .env("INPUT_PATHS", ".")
+            .env("INPUT_WORKING_DIRECTORY", ".")
+            .env("INPUT_FAIL_ON_VIOLATION", "true")
+            .env("INPUT_ANNOTATIONS", "true")
+            .env("INPUT_SUMMARY", "true")
+            .env("INPUT_MAX_ANNOTATIONS", "50")
+            .env("INPUT_LOG_LEVEL", "quiet");
+        command
+    }
+}
+
+#[test]
+fn action_emits_escaped_limited_annotations_outputs_and_one_summary() {
+    let fixture = ActionFixture::new();
+    write(
+        &fixture.workspace.join(".editorconfig"),
+        "root = true\n[*]\nindent_style = space\n",
+    );
+    write(&fixture.workspace.join("a,100%.txt"), "\tbad\n");
+    write(&fixture.workspace.join("second.txt"), "\tbad\n");
+    fixture
+        .command()
+        .env("INPUT_PATHS", "a,100%.txt\nsecond.txt")
+        .env("INPUT_MAX_ANNOTATIONS", "1")
+        .env("INPUT_FAIL_ON_VIOLATION", "false")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("file=a%2C100%25.txt,line=1,col=1")
+                .and(predicate::str::contains("1 annotations suppressed")),
+        );
+    assert_eq!(
+        fs::read_to_string(&fixture.output).unwrap(),
+        "outcome=violations\nviolations=2\nchecked-files=2\nskipped-files=0\n"
+    );
+    let summary = fs::read_to_string(&fixture.summary).unwrap();
+    assert_eq!(summary.matches("## ecci").count(), 1);
+    assert!(summary.contains("| 2 | 2 | 0 | 0 |"));
+}
+
+#[test]
+fn execution_errors_are_not_remapped() {
+    let fixture = ActionFixture::new();
+    fixture
+        .command()
+        .env("INPUT_PATHS", "missing")
+        .env("INPUT_FAIL_ON_VIOLATION", "false")
+        .assert()
+        .code(3);
+    assert!(fs::read_to_string(&fixture.output)
+        .unwrap()
+        .contains("outcome=io-error"));
+}
+
+#[test]
+fn workspace_escape_and_invalid_inputs_are_configuration_errors() {
+    let fixture = ActionFixture::new();
+    fixture
+        .command()
+        .env("INPUT_PATHS", "../outside")
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("ECCI-CONFIG"));
+    fixture
+        .command()
+        .env("INPUT_FAIL_ON_VIOLATION", "TRUE")
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("must be exactly true or false"));
+    let outside = fixture.temp.path().join("outside");
+    fs::create_dir(&outside).unwrap();
+    fixture
+        .command()
+        .env("INPUT_WORKING_DIRECTORY", outside)
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("outside GITHUB_WORKSPACE"));
+
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(fixture.temp.path(), fixture.workspace.join("escape")).unwrap();
+        fixture
+            .command()
+            .env("INPUT_PATHS", "escape/not-created")
+            .assert()
+            .code(2)
+            .stdout(predicate::str::contains("outside GITHUB_WORKSPACE"));
+    }
+}
+
+#[test]
+fn action_metadata_declares_the_complete_contract() {
+    let metadata =
+        fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/../../action.yml")).unwrap();
+    for name in [
+        "paths:",
+        "working-directory:",
+        "fail-on-violation:",
+        "annotations:",
+        "summary:",
+        "max-annotations:",
+        "log-level:",
+        "outcome:",
+        "violations:",
+        "checked-files:",
+        "skipped-files:",
+    ] {
+        assert!(metadata.contains(name), "missing metadata field {name}");
+    }
+    assert!(metadata.contains("using: 'docker'"));
+    assert!(metadata.contains("image: 'Dockerfile'"));
+    assert!(!metadata.contains("token"));
+
+    let workflow = fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/action-workflow.yml"
+    ))
+    .unwrap();
+    for input in [
+        "paths:",
+        "working-directory:",
+        "fail-on-violation:",
+        "annotations:",
+        "summary:",
+        "max-annotations:",
+        "log-level:",
+    ] {
+        assert!(workflow.contains(input), "smoke fixture omits {input}");
+    }
+    assert!(workflow.contains("permissions:\n  contents: read"));
+}
+
+#[test]
+fn container_entrypoint_smoke_test() {
+    Command::new("sh")
+        .arg(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/container-entrypoint.sh"
+        ))
+        .assert()
+        .success();
+}

--- a/crates/ecci/tests/container-entrypoint.sh
+++ b/crates/ecci/tests/container-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir "$tmp/workspace"
+if env GITHUB_WORKSPACE="$tmp/workspace" ECCI_BIN=/bin/true INPUT_PATHS=. \
+  INPUT_WORKING_DIRECTORY=. INPUT_FAIL_ON_VIOLATION=TRUE INPUT_ANNOTATIONS=true \
+  INPUT_SUMMARY=true INPUT_MAX_ANNOTATIONS=50 INPUT_LOG_LEVEL=summary \
+  "$root/entrypoint.sh" >"$tmp/stdout" 2>&1; then
+  echo 'entrypoint unexpectedly accepted invalid input' >&2
+  exit 1
+fi
+grep '::error title=ECCI-CONFIG::' "$tmp/stdout" >/dev/null
+env GITHUB_WORKSPACE="$tmp/workspace" ECCI_BIN=/bin/true INPUT_PATHS='one
+two' INPUT_WORKING_DIRECTORY=. INPUT_FAIL_ON_VIOLATION=false INPUT_ANNOTATIONS=false \
+  INPUT_SUMMARY=false INPUT_MAX_ANNOTATIONS=0 INPUT_LOG_LEVEL=quiet "$root/entrypoint.sh"

--- a/crates/ecci/tests/fixtures/action-workflow.yml
+++ b/crates/ecci/tests/fixtures/action-workflow.yml
@@ -1,0 +1,20 @@
+name: ecci Action smoke fixture
+on: workflow_dispatch
+permissions:
+  contents: read
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          paths: |
+            src
+            tests
+          working-directory: .
+          fail-on-violation: false
+          annotations: true
+          summary: true
+          max-annotations: 10
+          log-level: diagnostic

--- a/docs/design/cli-diagnostics-and-github-action.md
+++ b/docs/design/cli-diagnostics-and-github-action.md
@@ -4,8 +4,8 @@
 
 This document defines the public result-reporting contract for the `ecci`
 command-line interface (CLI) and its GitHub Action. The shared model, text
-renderer, target selection, and checker-backed CLI are implemented. Wiring the
-same model into the Action remains separate work.
+renderer, target selection, checker-backed CLI, and Docker Action presentation
+are implemented.
 
 The design distinguishes a **finding** (a checked file does not conform) from
 an **execution error** (the command could not reliably complete the requested

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -11,3 +11,5 @@ page from this index and, when it is a primary entry point, from the repository
   path selection, implemented checks, and current exit behavior.
 - [`.ecciignore` configuration](ecciignore.md) explains ignore locations,
   pattern syntax, precedence, negation, and binary force-check behavior.
+- [GitHub Action](github-action.md) explains workflow setup, inputs, outputs,
+  annotations, summaries, and failure behavior.

--- a/docs/user/github-action.md
+++ b/docs/user/github-action.md
@@ -1,0 +1,52 @@
+# GitHub Action
+
+The ecci GitHub Action checks repository files against their applicable
+`.editorconfig` settings. It uses workflow commands for annotations and the
+job summary, so it does not call the GitHub API or require a write token.
+
+## Basic usage
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: editorconfig-ecci/ecci@v1
+    with:
+      paths: |
+        src
+        tests
+```
+
+Each non-empty line in `paths` is a repository-relative file or directory.
+Directories are searched recursively. Paths and `working-directory` must
+resolve inside `GITHUB_WORKSPACE`; absolute paths and escapes through `..` or
+symbolic links are rejected.
+
+## Inputs
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `paths` | `.` | Newline-separated repository-relative files or directories. Empty lines are invalid. |
+| `working-directory` | `.` | Directory inside the workspace from which paths are resolved. |
+| `fail-on-violation` | `true` | When `false`, report violations without failing the step. Execution errors still fail. |
+| `annotations` | `true` | Emit location-aware workflow annotations. |
+| `summary` | `true` | Append one bounded result section to the job summary. |
+| `max-annotations` | `50` | Maximum annotations. `0` disables them; suppressed diagnostics are counted. |
+| `log-level` | `summary` | `quiet`, `summary`, `diagnostic`, or `debug`. |
+
+Boolean values are case-sensitive and accept only `true` or `false`.
+`max-annotations` accepts only a non-negative decimal integer. Invalid inputs
+are configuration errors.
+
+## Outputs and results
+
+| Output | Description |
+| --- | --- |
+| `outcome` | `success`, `violations`, `configuration-error`, `io-error`, or `internal-error`. |
+| `violations` | Number of violations. |
+| `checked-files` | Number of files fully checked. |
+| `skipped-files` | Number of intentionally skipped files. |
+
+With `fail-on-violation: false`, an `outcome` of `violations` has a successful
+step status. Configuration, input/output, and internal errors always fail. The
+Action's annotations appear on the workflow check when GitHub supports the
+reported location; no pull-request comment or additional permission is used.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,29 @@
 #!/bin/sh
+set -eu
 
-/usr/local/bin/ecci
+config_error() {
+  escaped=$(printf '%s' "$1" | sed -e 's/%/%25/g' -e 's/\r/%0D/g' -e 's/\n/%0A/g')
+  printf '::error title=ECCI-CONFIG::%s\n' "$escaped"
+  if [ -n "${GITHUB_OUTPUT-}" ]; then
+    printf 'outcome=configuration-error\nviolations=0\nchecked-files=0\nskipped-files=0\n' >> "$GITHUB_OUTPUT"
+  fi
+  if [ "${INPUT_SUMMARY-}" != false ] && [ -n "${GITHUB_STEP_SUMMARY-}" ]; then
+    printf '## ecci\n\n**Outcome:** configuration-error\n\n%s\n' "$1" >> "$GITHUB_STEP_SUMMARY"
+  fi
+  exit 2
+}
+
+validate_boolean() {
+  eval "value=\${$1-}"
+  case "$value" in true|false) ;; *) config_error "$2 must be exactly true or false" ;; esac
+}
+
+validate_boolean INPUT_FAIL_ON_VIOLATION fail-on-violation
+validate_boolean INPUT_ANNOTATIONS annotations
+validate_boolean INPUT_SUMMARY summary
+case "${INPUT_MAX_ANNOTATIONS-}" in ''|*[!0-9]*) config_error 'max-annotations must be a non-negative decimal integer' ;; esac
+case "${INPUT_LOG_LEVEL-}" in quiet|summary|diagnostic|debug) ;; *) config_error 'log-level must be quiet, summary, diagnostic, or debug' ;; esac
+[ -n "${INPUT_PATHS-}" ] || config_error 'paths must contain at least one non-empty line'
+[ -n "${INPUT_WORKING_DIRECTORY-}" ] || config_error 'working-directory must not be empty'
+
+exec "${ECCI_BIN:-/usr/local/bin/ecci}" --github-action


### PR DESCRIPTION
## Summary

- implement the first-release Docker GitHub Action input, output, annotation, summary, and exit-remapping contract on top of the typed report and file-selection work
- enforce workspace confinement and strict input validation without GitHub API or write-token dependencies
- add entrypoint, metadata, workflow fixture, integration, and container smoke coverage
- document GitHub Action usage and update documentation indexes

## Testing

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `sh crates/ecci/tests/container-entrypoint.sh`
- `docker build --target action -t ecci-action:test .`
- built-container smoke test for annotations, outputs, summary, and violation exit remapping
- `git diff --check`