### PR TITLE
Optimize format job tool setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,11 +23,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Setup Rust
-        uses: moonrepo/setup-rust@v1
-        with:
-          components: rustfmt
-          bins: taplo-cli
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+      - name: Install Taplo
+        uses: taiki-e/install-action@taplo
       - name: Run format
         run: |
           cargo fmt --all -- --check

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,11 +28,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Setup Rust
-        uses: moonrepo/setup-rust@v1
-        with:
-          components: rustfmt
-          bins: taplo-cli
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+      - name: Install Taplo
+        uses: taiki-e/install-action@taplo
       - name: Run format
         run: |
           cargo fmt --all -- --check


### PR DESCRIPTION
## Summary

- use the hosted runner Rust toolchain and explicitly ensure rustfmt is installed
- install Taplo from its upstream prebuilt release instead of compiling `taplo-cli` through the Rust setup action
- keep the pull-request and main Format jobs aligned

## Timing evidence

Six recent successful pull-request runs spent 125–249 seconds in `Setup Rust`, while `Run format` took 0–1 second. The setup logs show `taplo-cli` prebuilt lookup failures followed by a source build.

On this PR, both `Install rustfmt` and `Install Taplo` completed within the API’s one-second timestamp resolution. The complete Format job took 12 seconds, down from approximately 128–252 seconds in the sampled baseline runs.

## Validation

- `cargo fmt --all -- --check`
- `taplo format --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/pull_request.yml .github/workflows/main.yml`
- `git diff --check`
- all pull-request checks passed