### PR TITLE
Use install-action for cargo-udeps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Install udeps
-        run: cargo install cargo-udeps --locked
+        uses: taiki-e/install-action@cargo-udeps
       - name: Run udeps
         run: cargo +nightly udeps --all-targets
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
       - name: Install udeps
-        run: cargo install cargo-udeps --locked
+        uses: taiki-e/install-action@cargo-udeps
       - name: Run udeps
         run: cargo +nightly udeps --all-targets
 


### PR DESCRIPTION
## Summary

- install `cargo-udeps` with `taiki-e/install-action` in both CI workflows
- use the supported prebuilt GitHub Release binary instead of compiling with `cargo install`

## Verification

- `git diff --check`