### PR TITLE
Always exclude .git directories from traversal

### DIFF
--- a/crates/ecci/src/selection.rs
+++ b/crates/ecci/src/selection.rs
@@ -113,6 +113,10 @@ where
 }
 
 fn walk_directory(root: &Path, selection: &mut Selection, identities: &mut HashMap<Handle, usize>) {
+    if has_git_directory_component(root) {
+        return;
+    }
+
     let mut builder = WalkBuilder::new(root);
     builder
         .hidden(false)
@@ -127,9 +131,10 @@ fn walk_directory(root: &Path, selection: &mut Selection, identities: &mut HashM
             || !entry
                 .file_type()
                 .is_some_and(|file_type| file_type.is_dir())
-            || ignore_decision(&filter_root, entry.path(), true)
-                .map(|decision| decision.excluded.is_none())
-                .unwrap_or(true)
+            || (entry.file_name() != ".git"
+                && ignore_decision(&filter_root, entry.path(), true)
+                    .map(|decision| decision.excluded.is_none())
+                    .unwrap_or(true))
     });
 
     for entry in builder.build() {
@@ -184,6 +189,11 @@ fn walk_directory(root: &Path, selection: &mut Selection, identities: &mut HashM
             }
         }
     }
+}
+
+fn has_git_directory_component(path: &Path) -> bool {
+    path.components()
+        .any(|component| component.as_os_str() == ".git")
 }
 
 #[derive(Default)]
@@ -468,6 +478,69 @@ mod tests {
         assert_discovery_fixture(".ecciignore", "ecciignore.fixture");
     }
 
+    fn assert_git_directory_fixture(fixture: &str) {
+        let temp = configured_tree();
+        let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../testdata/file-discovery")
+            .join(fixture);
+        copy_tree(&fixture, temp.path());
+        fs::rename(
+            temp.path().join("git-dir.fixture"),
+            temp.path().join(".git"),
+        )
+        .unwrap();
+        fs::rename(
+            temp.path().join("nested/git-dir.fixture"),
+            temp.path().join("nested/.git"),
+        )
+        .unwrap();
+        fs::rename(
+            temp.path().join("ordinary/git-file.fixture"),
+            temp.path().join("ordinary/.git"),
+        )
+        .unwrap();
+
+        let selection = select_paths([temp.path()]);
+        let relative: Vec<_> = selection
+            .files
+            .iter()
+            .filter_map(|file| file.path.strip_prefix(temp.path()).ok())
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect();
+
+        assert!(relative.contains(&"visible.txt".into()));
+        assert!(relative.contains(&"ordinary/.git".into()));
+        assert!(relative.contains(&".github/workflow.txt".into()));
+        assert!(relative.contains(&"nested/visible.txt".into()));
+        assert!(!relative.iter().any(|path| path.starts_with(".git/")));
+        assert!(!relative.iter().any(|path| path.starts_with("nested/.git/")));
+    }
+
+    #[test]
+    fn git_directories_are_pruned_without_an_ignore_file() {
+        assert_git_directory_fixture("git-directory-no-ignore");
+    }
+
+    #[test]
+    fn git_directories_cannot_be_reincluded_by_ignore_patterns() {
+        assert_git_directory_fixture("git-directory-reincluded");
+    }
+
+    #[test]
+    fn explicitly_named_paths_do_not_bypass_git_directory_pruning() {
+        let temp = configured_tree();
+        let git_file = temp.path().join(".git");
+        write(&git_file, b"ordinary file\n");
+        let direct_file = select_paths([&git_file]);
+        assert_eq!(direct_file.files.len(), 1);
+
+        fs::remove_file(&git_file).unwrap();
+        let nested = temp.path().join(".git/objects");
+        write(&nested.join("object.txt"), b"not inspected\n");
+        assert!(select_paths([temp.path().join(".git")]).files.is_empty());
+        assert!(select_paths([nested]).files.is_empty());
+    }
+
     fn has_skip(selection: &Selection, name: &str, reason: SkipReason) -> bool {
         selection.outcomes.iter().any(|outcome| {
             matches!(
@@ -515,7 +588,6 @@ mod tests {
                 ".gitignore",
                 ".gitignore",
                 ".hidden",
-                "exclude",
                 "forced.bin",
                 "git-only.txt",
                 "keep.special",

--- a/docs/design/cli-file-selection.md
+++ b/docs/design/cli-file-selection.md
@@ -38,6 +38,13 @@ not follow symbolic links found during traversal, whether they point to files
 or directories. Such entries are skipped with the `symlink` reason. This
 avoids cycles, duplicate checks, and unexpectedly leaving the requested tree.
 
+Traversal never enters a directory named exactly `.git`, at any depth. This is
+an unconditional traversal invariant rather than an ignore rule, so neither a
+`.gitignore` nor `.ecciignore` negation can re-include it. Naming `.git` or one
+of its descendant directories as a traversal root does not bypass the
+invariant. A regular file named `.git` remains a candidate, as do paths with
+different names such as `.github`.
+
 The implementation must retain enough identity information to check a file at
 most once when the same file is supplied by more than one argument. Identity is
 the resolved regular file, not the spelling of the input path. On platforms
@@ -177,6 +184,7 @@ covered by automated CLI or selection-layer tests.
 | `.ecciignore` | Root and nested files apply hierarchically; its rules take precedence over `.gitignore`; a final negated rule re-includes a regular file and force-selects it for binary detection. |
 | Direct paths | A direct ignored regular file is selected; a direct directory honors ignore files; missing, unsupported, and broken-link paths are operational errors while later arguments continue. |
 | Defaults and traversal | Omitting positional paths behaves exactly like a single `.` directory argument; hidden files are candidates; traversal skips file and directory symlinks. |
+| Git metadata directories | Direct and nested directories named exactly `.git` are never enumerated, including without ignore files and when a negated ignore pattern attempts to re-include them; regular files named `.git` and differently named paths remain candidates. |
 | File identity | A target named directly, through one or more direct symlinks, and through traversal is checked once; any direct occurrence gives the merged candidate direct-file semantics, while the first occurrence supplies its display path. |
 | EditorConfig and binary detection | A file with applicable configuration reaches binary detection and then the checker; a file with no applicable `.editorconfig` is skipped with the correct reason; binary selection follows the binary-file design. |
 | Ignore decision API | Tests cover parent and nested rules, ignore followed by whitelist and whitelist followed by ignore, and disagreement between `.gitignore` and `.ecciignore`; the structured result records both final source matches, the effective exclusion, and `force_check` before binary classification. |

--- a/docs/user/ecciignore.md
+++ b/docs/user/ecciignore.md
@@ -34,6 +34,11 @@ over `.gitignore`. A normal `.ecciignore` match excludes the file. A final
 negated pattern, written with `!`, re-includes it even when `.gitignore` would
 exclude it. The `.ecciignore` file itself is never checked.
 
+Directories named exactly `.git` are never traversed, regardless of ignore or
+negation patterns. This also applies when such a directory or one of its
+descendants is named directly as a traversal root. A regular file named `.git`
+and differently named paths such as `.github` are not excluded by this rule.
+
 ## Binary files and force-check rules
 
 Before checking a candidate, `ecci` examines at most its first 8 KiB. Empty

--- a/testdata/file-discovery/git-directory-no-ignore/.github/workflow.txt
+++ b/testdata/file-discovery/git-directory-no-ignore/.github/workflow.txt
@@ -1,0 +1,1 @@
+checked

--- a/testdata/file-discovery/git-directory-no-ignore/git-dir.fixture/internal.txt
+++ b/testdata/file-discovery/git-directory-no-ignore/git-dir.fixture/internal.txt
@@ -1,0 +1,1 @@
+must not be inspected

--- a/testdata/file-discovery/git-directory-no-ignore/nested/git-dir.fixture/internal.txt
+++ b/testdata/file-discovery/git-directory-no-ignore/nested/git-dir.fixture/internal.txt
@@ -1,0 +1,1 @@
+must not be inspected

--- a/testdata/file-discovery/git-directory-no-ignore/nested/visible.txt
+++ b/testdata/file-discovery/git-directory-no-ignore/nested/visible.txt
@@ -1,0 +1,1 @@
+checked

--- a/testdata/file-discovery/git-directory-no-ignore/ordinary/git-file.fixture
+++ b/testdata/file-discovery/git-directory-no-ignore/ordinary/git-file.fixture
@@ -1,0 +1,1 @@
+ordinary file

--- a/testdata/file-discovery/git-directory-no-ignore/visible.txt
+++ b/testdata/file-discovery/git-directory-no-ignore/visible.txt
@@ -1,0 +1,1 @@
+checked

--- a/testdata/file-discovery/git-directory-reincluded/.ecciignore
+++ b/testdata/file-discovery/git-directory-reincluded/.ecciignore
@@ -1,0 +1,4 @@
+!.git/
+!.git/**
+!nested/.git/
+!nested/.git/**

--- a/testdata/file-discovery/git-directory-reincluded/.github/workflow.txt
+++ b/testdata/file-discovery/git-directory-reincluded/.github/workflow.txt
@@ -1,0 +1,1 @@
+checked

--- a/testdata/file-discovery/git-directory-reincluded/git-dir.fixture/internal.txt
+++ b/testdata/file-discovery/git-directory-reincluded/git-dir.fixture/internal.txt
@@ -1,0 +1,1 @@
+must not be inspected

--- a/testdata/file-discovery/git-directory-reincluded/nested/git-dir.fixture/internal.txt
+++ b/testdata/file-discovery/git-directory-reincluded/nested/git-dir.fixture/internal.txt
@@ -1,0 +1,1 @@
+must not be inspected

--- a/testdata/file-discovery/git-directory-reincluded/nested/visible.txt
+++ b/testdata/file-discovery/git-directory-reincluded/nested/visible.txt
@@ -1,0 +1,1 @@
+checked

--- a/testdata/file-discovery/git-directory-reincluded/ordinary/git-file.fixture
+++ b/testdata/file-discovery/git-directory-reincluded/ordinary/git-file.fixture
@@ -1,0 +1,1 @@
+ordinary file

--- a/testdata/file-discovery/git-directory-reincluded/visible.txt
+++ b/testdata/file-discovery/git-directory-reincluded/visible.txt
@@ -1,0 +1,1 @@
+checked


### PR DESCRIPTION
## Summary

- prune directories named exactly `.git` before ignore-rule evaluation
- prevent explicit nested traversal roots and negated ignore patterns from bypassing the exclusion
- add regression fixtures covering missing ignore files, re-inclusion attempts, exact-name matching, and nested `.git` directories
- document the traversal invariant in the user and design documentation

## Testing

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `git diff --check`