### PR TITLE
Replace numeric diagnostics with stable string codes

### DIFF
--- a/crates/ecci-checker/src/charset.rs
+++ b/crates/ecci-checker/src/charset.rs
@@ -16,7 +16,7 @@ pub fn check_charset<T: Output>(config: &Config, output: &mut T, bytes: &[u8]) {
             bytes.len(),
             &config.path.to_string_lossy(),
             &String::from_utf8_lossy(bytes),
-            "charset",
+            "charset.invalid_value",
         );
     }
 }
@@ -172,7 +172,7 @@ mod tests {
                     *line == 1
                         && *start == 0
                         && path == target_path
-                        && rule == "charset"
+                        && rule == "charset.invalid_value"
                         && (*length > 0 || (*length == 0 && path.ends_with("error_empty.target")))
                 })
                 .return_const(());

--- a/crates/ecci-checker/src/end_of_line.rs
+++ b/crates/ecci-checker/src/end_of_line.rs
@@ -17,7 +17,7 @@ pub fn check_end_of_line<T: Output>(
                     1,
                     &config.path.to_string_lossy(),
                     content,
-                    "end_of_line",
+                    "end_of_line.invalid_value",
                 );
             }
         }
@@ -33,7 +33,7 @@ pub fn check_end_of_line<T: Output>(
                     1,
                     &config.path.to_string_lossy(),
                     content,
-                    "end_of_line",
+                    "end_of_line.invalid_value",
                 );
             }
             if c == '\n' && (i == 0 || content.as_bytes()[i - 1] != b'\r') {
@@ -43,7 +43,7 @@ pub fn check_end_of_line<T: Output>(
                     1,
                     &config.path.to_string_lossy(),
                     content,
-                    "end_of_line",
+                    "end_of_line.invalid_value",
                 );
             }
         }
@@ -56,7 +56,7 @@ pub fn check_end_of_line<T: Output>(
                     1,
                     &config.path.to_string_lossy(),
                     content,
-                    "end_of_line",
+                    "end_of_line.invalid_value",
                 );
             }
         }
@@ -123,7 +123,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "a\rb\rc\r"
-                    && rule == "end_of_line"
+                    && rule == "end_of_line.invalid_value"
             })
             .return_const(());
         mock.expect_output()
@@ -134,7 +134,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "a\rb\rc\r"
-                    && rule == "end_of_line"
+                    && rule == "end_of_line.invalid_value"
             })
             .return_const(());
         mock.expect_output()
@@ -145,7 +145,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "a\rb\rc\r"
-                    && rule == "end_of_line"
+                    && rule == "end_of_line.invalid_value"
             })
             .return_const(());
         check_all(&config, &mut mock).unwrap();
@@ -164,7 +164,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "a\r\n"
-                    && rule == "end_of_line"
+                    && rule == "end_of_line.invalid_value"
             })
             .return_const(());
         mock.expect_output()
@@ -175,7 +175,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "b\r\n"
-                    && rule == "end_of_line"
+                    && rule == "end_of_line.invalid_value"
             })
             .return_const(());
         mock.expect_output()
@@ -186,7 +186,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "c\r\n"
-                    && rule == "end_of_line"
+                    && rule == "end_of_line.invalid_value"
             })
             .return_const(());
         check_all(&config, &mut mock).unwrap();
@@ -216,7 +216,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "a\nb\nc\n"
-                    && rule == "end_of_line"
+                    && rule == "end_of_line.invalid_value"
             })
             .return_const(());
         mock.expect_output()
@@ -227,7 +227,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "a\nb\nc\n"
-                    && rule == "end_of_line"
+                    && rule == "end_of_line.invalid_value"
             })
             .return_const(());
         mock.expect_output()
@@ -238,7 +238,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "a\nb\nc\n"
-                    && rule == "end_of_line"
+                    && rule == "end_of_line.invalid_value"
             })
             .return_const(());
         check_all(&config, &mut mock).unwrap();
@@ -259,7 +259,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "a\r"
-                    && rule == "end_of_line"
+                    && rule == "end_of_line.invalid_value"
             })
             .return_const(());
         mock.expect_output()
@@ -270,7 +270,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "\nb\r"
-                    && rule == "end_of_line"
+                    && rule == "end_of_line.invalid_value"
             })
             .return_const(());
         mock.expect_output()
@@ -281,7 +281,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "\nc\r"
-                    && rule == "end_of_line"
+                    && rule == "end_of_line.invalid_value"
             })
             .return_const(());
         mock.expect_output()
@@ -292,7 +292,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "\n"
-                    && rule == "end_of_line"
+                    && rule == "end_of_line.invalid_value"
             })
             .return_const(());
         check_all(&config, &mut mock).unwrap();
@@ -312,7 +312,11 @@ mod tests {
     fn check_eol_crlf_cr() {
         assert_eq!(
             eol_rules("../../testdata/end_of_line/crlf/error_cr.target"),
-            vec!["end_of_line", "end_of_line", "end_of_line"]
+            vec![
+                "end_of_line.invalid_value",
+                "end_of_line.invalid_value",
+                "end_of_line.invalid_value"
+            ]
         );
     }
 
@@ -320,7 +324,11 @@ mod tests {
     fn check_eol_crlf_lf() {
         assert_eq!(
             eol_rules("../../testdata/end_of_line/crlf/error_lf.target"),
-            vec!["end_of_line", "end_of_line", "end_of_line"]
+            vec![
+                "end_of_line.invalid_value",
+                "end_of_line.invalid_value",
+                "end_of_line.invalid_value"
+            ]
         );
     }
 
@@ -328,7 +336,7 @@ mod tests {
     fn check_eol_lf_reports_every_non_lf_terminator_in_mixed_file() {
         assert_eq!(
             eol_rules("../../testdata/end_of_line/lf_mixed/error_mixed.target"),
-            vec!["end_of_line", "end_of_line"]
+            vec!["end_of_line.invalid_value", "end_of_line.invalid_value"]
         );
     }
 

--- a/crates/ecci-checker/src/indent_size.rs
+++ b/crates/ecci-checker/src/indent_size.rs
@@ -25,7 +25,7 @@ pub fn check_indent_size<T: Output>(
                     indent,
                     &config.path.to_string_lossy(),
                     content,
-                    "indent_size",
+                    "indent_size.invalid_value",
                 );
             }
         }
@@ -60,7 +60,7 @@ mod tests {
                     && *length == 3
                     && path == target_path
                     && content == "   b\n"
-                    && rule == "indent_size"
+                    && rule == "indent_size.invalid_value"
             })
             .return_const(());
         check_all(&config, &mut mock).unwrap();
@@ -90,7 +90,7 @@ mod tests {
                     && *length == 2
                     && path == target_path
                     && content == "  b\n"
-                    && rule == "indent_size"
+                    && rule == "indent_size.invalid_value"
             })
             .return_const(());
         check_all(&config, &mut mock).unwrap();
@@ -110,7 +110,7 @@ mod tests {
                     && *length == 3
                     && path == target_path
                     && content == "   b\n"
-                    && rule == "indent_size"
+                    && rule == "indent_size.invalid_value"
             })
             .return_const(());
         check_all(&config, &mut mock).unwrap();
@@ -183,7 +183,7 @@ mod tests {
                     && *length == 2
                     && path == target_path
                     && content == "  b\n"
-                    && rule == "indent_size"
+                    && rule == "indent_size.invalid_value"
             })
             .return_const(());
         check_all(&config, &mut mock).unwrap();

--- a/crates/ecci-checker/src/indent_style.rs
+++ b/crates/ecci-checker/src/indent_style.rs
@@ -31,7 +31,7 @@ pub fn check_indent_style<T: Output>(
             1,
             &config.path.to_string_lossy(),
             content,
-            "indent_style",
+            "indent_style.invalid_value",
         )
     }
 }
@@ -63,7 +63,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "\t\tb\n"
-                    && rule == "indent_style"
+                    && rule == "indent_style.invalid_value"
             })
             .times(1)
             .return_const(());
@@ -103,7 +103,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "  b\n"
-                    && rule == "indent_style"
+                    && rule == "indent_style.invalid_value"
             })
             .times(1)
             .return_const(());
@@ -167,7 +167,7 @@ mod tests {
                         && *length == 1
                         && path == target_path
                         && content == expected_content
-                        && rule == "indent_style"
+                        && rule == "indent_style.invalid_value"
                 })
                 .once()
                 .return_const(());

--- a/crates/ecci-checker/src/insert_final_newline.rs
+++ b/crates/ecci-checker/src/insert_final_newline.rs
@@ -17,7 +17,7 @@ pub fn check_insert_final_newline<T: Output>(
                 0,
                 &config.path.to_string_lossy(),
                 content,
-                "insert_final_newline",
+                "insert_final_newline.missing",
             )
         }
     }
@@ -69,7 +69,7 @@ mod tests {
                     && *length == 0
                     && path == target_path
                     && content == "c"
-                    && rule == "insert_final_newline"
+                    && rule == "insert_final_newline.missing"
             })
             .return_const(());
         check_all(&config, &mut mock).unwrap();
@@ -119,7 +119,7 @@ mod tests {
                     && *length == 0
                     && path == target_path
                     && content == "a"
-                    && rule == "insert_final_newline"
+                    && rule == "insert_final_newline.missing"
             })
             .return_const(());
         check_all(&config, &mut mock).unwrap();
@@ -161,7 +161,7 @@ mod tests {
                     && *length == 0
                     && path == target_path
                     && content == "a"
-                    && rule == "insert_final_newline"
+                    && rule == "insert_final_newline.missing"
             })
             .return_const(());
         check_all(&config, &mut mock).unwrap();
@@ -191,6 +191,9 @@ mod tests {
 
         check_all(&config, &mut output).unwrap();
 
-        assert_eq!(output.rules, vec!["end_of_line", "end_of_line"]);
+        assert_eq!(
+            output.rules,
+            vec!["end_of_line.invalid_value", "end_of_line.invalid_value"]
+        );
     }
 }

--- a/crates/ecci-checker/src/max_line_length.rs
+++ b/crates/ecci-checker/src/max_line_length.rs
@@ -17,7 +17,7 @@ pub fn check_max_line_length<T: Output>(
                 trimmed.len() - max_line_length,
                 &config.path.to_string_lossy(),
                 content,
-                "max_line_length",
+                "max_line_length.exceeded",
             );
         }
     }
@@ -51,7 +51,7 @@ mod tests {
                     && *length == 2
                     && path == target_path
                     && content == "bbbbbbbbbbbb\n"
-                    && rule == "max_line_length"
+                    && rule == "max_line_length.exceeded"
             })
             .return_const(());
         check_all(&config, &mut mock).unwrap();
@@ -81,7 +81,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "\t\t\t\t\t\n"
-                    && rule == "max_line_length"
+                    && rule == "max_line_length.exceeded"
             })
             .return_const(());
         check_all(&config, &mut mock).unwrap();
@@ -115,7 +115,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "aaaaa\r\n"
-                    && rule == "max_line_length"
+                    && rule == "max_line_length.exceeded"
             })
             .return_const(());
         check_all(&config, &mut mock).unwrap();
@@ -161,7 +161,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "あいうえおか\n"
-                    && rule == "max_line_length"
+                    && rule == "max_line_length.exceeded"
             })
             .return_const(());
         check_all(&config, &mut mock).unwrap();

--- a/crates/ecci-checker/src/trim_trailing_whitespace.rs
+++ b/crates/ecci-checker/src/trim_trailing_whitespace.rs
@@ -26,7 +26,7 @@ pub fn check_trim_trailing_whitespace<T: Output>(
                 line.len() - whitespace_start,
                 &config.path.to_string_lossy(),
                 content,
-                "trim_trailing_whitespace",
+                "trim_trailing_whitespace.present",
             )
         }
     }
@@ -59,7 +59,7 @@ mod tests {
                     && *length == 2
                     && path == target_path
                     && content == "b  \n"
-                    && rule == "trim_trailing_whitespace"
+                    && rule == "trim_trailing_whitespace.present"
             })
             .times(1)
             .return_const(());
@@ -79,7 +79,7 @@ mod tests {
                     && *length == 2
                     && path == target_path
                     && content == "  \n"
-                    && rule == "trim_trailing_whitespace"
+                    && rule == "trim_trailing_whitespace.present"
             })
             .times(1)
             .return_const(());
@@ -109,7 +109,7 @@ mod tests {
                     && *length == 1
                     && path == target_path
                     && content == "text \n"
-                    && rule == "trim_trailing_whitespace"
+                    && rule == "trim_trailing_whitespace.present"
             })
             .times(1)
             .return_const(());
@@ -153,7 +153,7 @@ mod tests {
                             && *actual_length == length
                             && path == target_path
                             && actual_content == content
-                            && rule == "trim_trailing_whitespace"
+                            && rule == "trim_trailing_whitespace.present"
                     },
                 )
                 .once()
@@ -187,7 +187,7 @@ mod tests {
                     && *length == 0
                     && path == target_path
                     && content == "last line has a trailing space "
-                    && rule == "insert_final_newline"
+                    && rule == "insert_final_newline.missing"
             })
             .times(1)
             .return_const(());

--- a/crates/ecci-report/src/lib.rs
+++ b/crates/ecci-report/src/lib.rs
@@ -25,10 +25,10 @@ impl DiagnosticCode {
     pub fn as_str(&self) -> &str {
         match self {
             Self::Finding(code) => code,
-            Self::Skip => "ECCI-SKIP",
-            Self::Configuration => "ECCI-CONFIG",
-            Self::Io => "ECCI-IO",
-            Self::Internal => "ECCI-INTERNAL",
+            Self::Skip => "selection.skipped",
+            Self::Configuration => "config.invalid",
+            Self::Io => "io.failed",
+            Self::Internal => "internal.unexpected",
         }
     }
 }

--- a/crates/ecci-report/src/tests.rs
+++ b/crates/ecci-report/src/tests.rs
@@ -6,7 +6,7 @@ fn nonzero(value: usize) -> NonZeroUsize {
 
 fn finding() -> Diagnostic {
     let mut finding = Finding::new(
-        "ECCI001",
+        "indent_style.invalid_value",
         "indent_style",
         "indent_style must be space; found tab",
     );
@@ -23,25 +23,25 @@ fn execution_error(kind: ExecutionErrorKind) -> Diagnostic {
 #[test]
 fn exposes_stable_codes_categories_and_finding_values() {
     let finding = finding();
-    assert_eq!(finding.code().as_str(), "ECCI001");
+    assert_eq!(finding.code().as_str(), "indent_style.invalid_value");
     assert_eq!(finding.category(), Category::Finding);
     let skip = Diagnostic::IntentionalSkip(IntentionalSkip {
         message: "no .editorconfig applies; skipped".into(),
         location: None,
     });
-    assert_eq!(skip.code().as_str(), "ECCI-SKIP");
+    assert_eq!(skip.code().as_str(), "selection.skipped");
     assert_eq!(skip.category(), Category::IntentionalSkip);
 
     for (kind, code, category) in [
         (
             ExecutionErrorKind::Configuration,
-            "ECCI-CONFIG",
+            "config.invalid",
             Category::ConfigurationError,
         ),
-        (ExecutionErrorKind::Io, "ECCI-IO", Category::IoError),
+        (ExecutionErrorKind::Io, "io.failed", Category::IoError),
         (
             ExecutionErrorKind::Internal,
-            "ECCI-INTERNAL",
+            "internal.unexpected",
             Category::InternalError,
         ),
     ] {
@@ -61,8 +61,8 @@ fn renders_diagnostics_with_and_without_locations() {
     assert_eq!(
         render_text(&report, TextRenderOptions::default()),
         concat!(
-            "error[ECCI001] src/lib.rs:14:1: indent_style must be space; found tab\n",
-            "error[ECCI-INTERNAL]: could not complete check\n",
+            "error[indent_style.invalid_value] src/lib.rs:14:1: indent_style must be space; found tab\n",
+            "error[internal.unexpected]: could not complete check\n",
             "Checked 1 files: 1 violations, 0 skipped, 1 execution errors.\n"
         )
     );
@@ -158,9 +158,8 @@ fn renderer_keeps_each_diagnostic_and_debug_cause_on_one_line() {
             ..TextRenderOptions::default()
         },
     );
-    assert!(
-        rendered.starts_with("error[ECCI-IO]: failed to read\n  debug: caused by: first  second\n")
-    );
+    assert!(rendered
+        .starts_with("error[io.failed]: failed to read\n  debug: caused by: first  second\n"));
 }
 
 #[test]

--- a/crates/ecci/src/main.rs
+++ b/crates/ecci/src/main.rs
@@ -163,14 +163,17 @@ impl ecci_checker::Output for CheckerOutput<'_> {
         content: &str,
         rule: &str,
     ) {
-        let (code, expected, observed) = finding_values(self.config, rule, content, start);
+        let (property, _kind) = rule
+            .split_once('.')
+            .expect("checker diagnostic codes must use property.kind");
+        let (expected, observed) = finding_values(self.config, property, content, start);
         let message = match (&expected, &observed) {
             (Some(expected), Some(observed)) => {
-                format!("{rule} must be {expected}; found {observed}")
+                format!("{property} must be {expected}; found {observed}")
             }
-            _ => format!("{rule} does not conform"),
+            _ => format!("{property} does not conform"),
         };
-        let mut finding = Finding::new(code, rule, message);
+        let mut finding = Finding::new(rule, property, message);
         finding.expected = expected;
         finding.observed = observed;
         finding.location = Some(Location::at(
@@ -187,17 +190,7 @@ fn finding_values(
     rule: &str,
     content: &str,
     start: usize,
-) -> (&'static str, Option<String>, Option<String>) {
-    let code = match rule {
-        "indent_style" => "ECCI001",
-        "indent_size" => "ECCI002",
-        "end_of_line" => "ECCI003",
-        "charset" => "ECCI004",
-        "trim_trailing_whitespace" => "ECCI005",
-        "insert_final_newline" => "ECCI006",
-        "max_line_length" => "ECCI007",
-        _ => "ECCI000",
-    };
+) -> (Option<String>, Option<String>) {
     let observed = match rule {
         "indent_style" => content
             .as_bytes()
@@ -232,7 +225,7 @@ fn finding_values(
         "max_line_length" => config.max_line_length.map(|value| value.to_string()),
         _ => None,
     };
-    (code, expected, observed)
+    (expected, observed)
 }
 
 fn skip_message(reason: SkipReason) -> &'static str {

--- a/crates/ecci/tests/action.rs
+++ b/crates/ecci/tests/action.rs
@@ -151,8 +151,8 @@ fn action_uses_the_cli_selection_report_and_failure_semantics() {
             )),
         )
         .stderr(
-            predicate::str::contains("error[ECCI001] forced.dat:1:1").and(
-                predicate::str::contains("error[ECCI007] nested/nested.txt:1:4"),
+            predicate::str::contains("error[indent_style.invalid_value] forced.dat:1:1").and(
+                predicate::str::contains("error[max_line_length.exceeded] nested/nested.txt:1:4"),
             ),
         );
     assert_eq!(
@@ -217,7 +217,7 @@ fn workspace_escape_and_invalid_inputs_are_configuration_errors() {
         .env("INPUT_PATHS", "../outside")
         .assert()
         .code(2)
-        .stdout(predicate::str::contains("ECCI-CONFIG"));
+        .stdout(predicate::str::contains("config.invalid"));
     fixture
         .command()
         .env("INPUT_FAIL_ON_VIOLATION", "TRUE")

--- a/crates/ecci/tests/cli.rs
+++ b/crates/ecci/tests/cli.rs
@@ -87,7 +87,7 @@ fn violation_has_stable_code_and_one_based_location() {
         .code(1)
         .stdout("Checked 1 files: 1 violations, 0 skipped, 0 execution errors.\n")
         .stderr(predicate::str::contains(
-            "error[ECCI001] target.txt:2:1: indent_style must be space; found tab\n",
+            "error[indent_style.invalid_value] target.txt:2:1: indent_style must be space; found tab\n",
         ));
 }
 
@@ -101,7 +101,7 @@ fn malformed_configuration_is_status_two_without_platform_error_prose() {
         .code(2)
         .stdout("Checked 0 files: 0 violations, 0 skipped, 1 execution errors.\n")
         .stderr(
-            predicate::str::contains("error[ECCI-CONFIG]")
+            predicate::str::contains("error[config.invalid]")
                 .and(predicate::str::contains("resolve .editorconfig failed")),
         );
 }
@@ -116,7 +116,7 @@ fn missing_target_is_status_three_and_message_is_operation_based() {
         .code(3)
         .stdout("Checked 0 files: 0 violations, 0 skipped, 1 execution errors.\n")
         .stderr(
-            predicate::str::contains("error[ECCI-IO]")
+            predicate::str::contains("error[io.failed]")
                 .and(predicate::str::contains("inspect direct path failed")),
         );
 }
@@ -154,7 +154,7 @@ fn skipped_target_is_counted_and_only_shown_on_request() {
         .assert()
         .success()
         .stderr(predicate::str::contains(
-            "warning[ECCI-SKIP] plain.txt: no .editorconfig applies; skipped",
+            "warning[selection.skipped] plain.txt: no .editorconfig applies; skipped",
         ));
 }
 
@@ -169,8 +169,8 @@ fn independent_mixed_errors_continue_and_execution_error_wins() {
         .code(3)
         .stdout("Checked 1 files: 1 violations, 0 skipped, 1 execution errors.\n")
         .stderr(
-            predicate::str::contains("error[ECCI001]")
-                .and(predicate::str::contains("error[ECCI-IO]")),
+            predicate::str::contains("error[indent_style.invalid_value]")
+                .and(predicate::str::contains("error[io.failed]")),
         );
 }
 
@@ -183,7 +183,7 @@ fn invalid_and_duplicate_controls_are_configuration_errors() {
             .args(args)
             .assert()
             .code(2)
-            .stderr(predicate::str::contains("error[ECCI-CONFIG]"));
+            .stderr(predicate::str::contains("error[config.invalid]"));
     }
 }
 
@@ -198,15 +198,15 @@ fn release_fixture_covers_encoding_binary_ignore_and_nested_config_semantics() {
         .code(1)
         .stdout("Checked 9 files: 2 violations, 2 skipped, 0 execution errors.\n")
         .stderr(
-            predicate::str::contains("error[ECCI001] forced.dat:1:1")
+            predicate::str::contains("error[indent_style.invalid_value] forced.dat:1:1")
                 .and(predicate::str::contains(
-                    "error[ECCI007] nested/nested.txt:1:4",
+                    "error[max_line_length.exceeded] nested/nested.txt:1:4",
                 ))
                 .and(predicate::str::contains(
-                    "warning[ECCI-SKIP] binary.dat: binary file; skipped",
+                    "warning[selection.skipped] binary.dat: binary file; skipped",
                 ))
                 .and(predicate::str::contains(
-                    "warning[ECCI-SKIP] ignored.txt: excluded by .gitignore; skipped",
+                    "warning[selection.skipped] ignored.txt: excluded by .gitignore; skipped",
                 ))
                 .and(predicate::str::contains("bom.utf16le").not())
                 .and(predicate::str::contains("bom.utf16be").not())

--- a/crates/ecci/tests/container-entrypoint.sh
+++ b/crates/ecci/tests/container-entrypoint.sh
@@ -11,7 +11,7 @@ if env GITHUB_WORKSPACE="$tmp/workspace" ECCI_BIN=/bin/true INPUT_PATHS=. \
   echo 'entrypoint unexpectedly accepted invalid input' >&2
   exit 1
 fi
-grep '::error title=ECCI-CONFIG::' "$tmp/stdout" >/dev/null
+grep '::error title=config.invalid::' "$tmp/stdout" >/dev/null
 env GITHUB_WORKSPACE="$tmp/workspace" ECCI_BIN=/bin/true INPUT_PATHS='one
 two' INPUT_WORKING_DIRECTORY=. INPUT_FAIL_ON_VIOLATION=false INPUT_ANNOTATIONS=false \
   INPUT_SUMMARY=false INPUT_MAX_ANNOTATIONS=0 INPUT_LOG_LEVEL=quiet "$root/entrypoint.sh"

--- a/docs/design/cli-diagnostics-and-github-action.md
+++ b/docs/design/cli-diagnostics-and-github-action.md
@@ -62,32 +62,68 @@ machine-readable API. One diagnostic is rendered on one line; the location is
 omitted when unavailable. Findings use `error`, skipped work uses `warning`,
 and fatal execution errors use `error`. Detailed progress is never mixed into
 the diagnostic stream unless requested. Skip diagnostics are not shown by
-default. `--show-skips` requests their `ECCI-SKIP` warning lines; skipped files
+default. `--show-skips` requests their `selection.skipped` warning lines; skipped files
 remain counted in either mode.
 
 ```text
-error[ECCI001] src/lib.rs:14:1: indent_style must be space; found tab
-error[ECCI002] src/lib.rs:47:81: max_line_length must be 80; found 96
-warning[ECCI-SKIP] docs/generated.md: no .editorconfig applies; skipped
+error[indent_style.invalid_value] src/lib.rs:14:1: indent_style must be space; found tab
+error[max_line_length.exceeded] src/lib.rs:47:81: max_line_length must be 80; found 96
+warning[selection.skipped] docs/generated.md: no .editorconfig applies; skipped
 Checked 2 files: 2 violations, 1 skipped, 0 execution errors.
 ```
 
-The category codes are stable identifiers for documentation, JSON, SARIF, and
-tests. `ECCI001` and similar property-check codes identify violations;
-`ECCI-CONFIG`, `ECCI-IO`, and `ECCI-INTERNAL` identify the execution-error
-categories; `ECCI-SKIP` identifies an intentional skip. The message may gain
+Codes are stable identifiers for documentation, JSON, SARIF, and tests. A
+property finding uses `<property>.<kind>`. The checker, which knows the precise
+failure, supplies the complete code rather than relying on a renderer-side
+property-to-code table. A new check for an existing property must receive a
+distinct kind when users can act on it differently. Kinds use lower-case
+snake_case and describe the observed failure, such as `invalid_value`,
+`missing`, `present`, or `exceeded`; an existing code must never be repurposed.
+
+Diagnostics without a direct EditorConfig property use reserved namespaces:
+`config` for command-line, Action-input, syntax, and configuration-resolution
+failures; `io` for filesystem operations; `internal` for invariant failures;
+and `selection` for target-selection outcomes. Their form is likewise
+`<namespace>.<kind>`. Current category-level codes are `config.invalid`,
+`io.failed`, `internal.unexpected`, and `selection.skipped`. More specific kinds
+may be added without colliding with property names. The message may gain
 context but must not be the only way to classify a diagnostic.
+
+This migration is intentionally breaking. The project is still on a `0.x`
+release line, and the release workflow classifies such changes with its
+`breaking`/`major` category. Emitting both identifiers would make the code field
+ambiguous, so renderers expose only the new identifier. The complete migration
+inventory is:
+
+| Previous code | Stable string code | Producer |
+| --- | --- | --- |
+| `ECCI001` | `indent_style.invalid_value` | `indent_style` checker |
+| `ECCI002` | `indent_size.invalid_value` | `indent_size` checker |
+| `ECCI003` | `end_of_line.invalid_value` | `end_of_line` checker |
+| `ECCI004` | `charset.invalid_value` | `charset` checker |
+| `ECCI005` | `trim_trailing_whitespace.present` | `trim_trailing_whitespace` checker |
+| `ECCI006` | `insert_final_newline.missing` | `insert_final_newline` checker |
+| `ECCI007` | `max_line_length.exceeded` | `max_line_length` checker |
+| `ECCI-CONFIG` | `config.invalid` | CLI, configuration resolver, and Action input validation |
+| `ECCI-IO` | `io.failed` | file selection and checking operations |
+| `ECCI-INTERNAL` | `internal.unexpected` | report and CLI failure boundary |
+| `ECCI-SKIP` | `selection.skipped` | file selection |
+
+The text renderer preserves `severity[code] location: message`. GitHub Action
+annotation titles and job-summary finding entries use the same code from the
+typed report. Tests cover the report model and renderer, CLI output, Action log
+output, and container-entrypoint validation.
 
 The following cases have these required meanings and text examples:
 
 | Case | Required diagnostic and summary behavior | Example |
 | --- | --- | --- |
-| Violation | Emit one `error[ECCIxxx]` finding for each reportable violation, retain checking other files, and summarize the count. | `error[ECCI001] src/lib.rs:14:1: indent_style must be space; found tab` |
-| Configuration error | Emit `error[ECCI-CONFIG]`; do not claim the affected target was checked. Continue only with independent targets when safe. | `error[ECCI-CONFIG] .editorconfig:12: invalid indent_size value "many"` |
-| I/O error | Emit `error[ECCI-IO]` with the affected path and operation; do not claim that target was checked. Continue only with independent targets when safe. | `error[ECCI-IO] src/lib.rs: failed to read file: Permission denied` |
-| Internal error | Emit exactly one user-safe `error[ECCI-INTERNAL]` summary, without a backtrace by default, and stop normal checking. | `error[ECCI-INTERNAL]: unexpected checker failure; rerun with --debug and report this error` |
+| Violation | Emit one property finding for each reportable violation, retain checking other files, and summarize the count. | `error[indent_style.invalid_value] src/lib.rs:14:1: indent_style must be space; found tab` |
+| Configuration error | Emit `error[config.invalid]`; do not claim the affected target was checked. Continue only with independent targets when safe. | `error[config.invalid] .editorconfig:12: invalid indent_size value "many"` |
+| I/O error | Emit `error[io.failed]` with the affected path and operation; do not claim that target was checked. Continue only with independent targets when safe. | `error[io.failed] src/lib.rs: failed to read file: Permission denied` |
+| Internal error | Emit exactly one user-safe `error[internal.unexpected]` summary, without a backtrace by default, and stop normal checking. | `error[internal.unexpected]: unexpected checker failure; rerun with --debug and report this error` |
 | No targets | Emit no per-file diagnostic and a summary that explicitly says no targets were selected. | `Checked 0 files: no targets selected.` |
-| No applicable `.editorconfig` | Treat the target as skipped, not conforming or failing; emit a warning only when skips are shown and count it in the summary. | `warning[ECCI-SKIP] README.md: no .editorconfig applies; skipped` |
+| No applicable `.editorconfig` | Treat the target as skipped, not conforming or failing; emit a warning only when skips are shown and count it in the summary. | `warning[selection.skipped] README.md: no .editorconfig applies; skipped` |
 
 `--debug` may add causal-chain details for execution errors to stderr, but it
 must not change the category, exit code, or the normal diagnostic message.
@@ -135,7 +171,7 @@ report model as the CLI. Its first-release interface is defined as follows:
 | `log-level` | No | `summary` | One of `quiet`, `summary`, `diagnostic`, or `debug`; controls ordinary log volume, never the final status. |
 
 Boolean and numeric inputs must be validated strictly. Invalid input is an
-Action configuration error, produces an `ECCI-CONFIG` annotation when possible,
+Action configuration error, produces a `config.invalid` annotation when possible,
 and fails the Action. The Action must reject a `working-directory` or path that
 resolves outside `GITHUB_WORKSPACE`.
 
@@ -164,8 +200,8 @@ Action canonicalizes its longest existing ancestor and lexically appends the
 remaining components. The resulting resolved path must also remain within the
 canonical workspace. This catches an escape through an existing symbolic-link
 ancestor even when the final component does not exist. A contained nonexistent
-path proceeds to normal selection and becomes `ECCI-IO`; either a lexical or
-resolved escape is `ECCI-CONFIG`.
+path proceeds to normal selection and becomes `io.failed`; either a lexical or
+resolved escape is `config.invalid`.
 
 Action input de-duplication uses the lexically normalized absolute path as its
 key, with the platform's normal path-comparison semantics, and retains the

--- a/docs/design/cli-file-selection.md
+++ b/docs/design/cli-file-selection.md
@@ -135,13 +135,13 @@ does not submit to checking. At minimum, outcomes distinguish:
 
 An outcome includes the affected path and, for errors, enough diagnostic
 detail to identify the failing operation. The reporting contract maps
-intentional skips to `ECCI-SKIP` diagnostics when skips are shown and maps
-operational errors to `ECCI-IO`. It defines the human-readable text format,
+intentional skips to `selection.skipped` diagnostics when skips are shown and maps
+operational errors to `io.failed`. It defines the human-readable text format,
 summary, and future machine-readable formats.
 
 Skip diagnostics are hidden in normal CLI output by default, while every skip
 is still retained in the typed report and included in the aggregate skipped
-count. `--show-skips` emits one `ECCI-SKIP` warning per retained skip. This flag
+count. `--show-skips` emits one `selection.skipped` warning per retained skip. This flag
 changes presentation only; it does not change selection, counts, or exit
 status. There is no negative form because hidden is the default.
 

--- a/docs/user/cli.md
+++ b/docs/user/cli.md
@@ -21,7 +21,7 @@ targets from being processed.
 
 ## Options
 
-- `--show-skips` writes an `ECCI-SKIP` warning for each skipped path. Skips are
+- `--show-skips` writes a `selection.skipped` warning for each skipped path. Skips are
   always counted but hidden by default.
 - `--debug` adds sanitized causal details for execution errors without changing
   categories, counts, or exit status.
@@ -38,14 +38,31 @@ one-based lines and columns whenever available. The final summary is written to
 standard output.
 
 ```text
-error[ECCI001] src/lib.rs:14:1: indent_style must be space; found tab
+error[indent_style.invalid_value] src/lib.rs:14:1: indent_style must be space; found tab
 Checked 1 files: 1 violations, 0 skipped, 0 execution errors.
 ```
 
-Finding codes identify checked properties. `ECCI-CONFIG`, `ECCI-IO`, and
-`ECCI-INTERNAL` identify execution errors; `ECCI-SKIP` identifies an intentional
-skip. Human-readable text is not a machine-readable API. An empty selection is
-reported as `Checked 0 files: no targets selected.`
+Finding codes use `<property>.<kind>` so that the property and reason can be
+identified without parsing the message. Current codes are:
+
+| Code | Meaning |
+| --- | --- |
+| `indent_style.invalid_value` | An indentation character conflicts with `indent_style`. |
+| `indent_size.invalid_value` | Space indentation is not a multiple of `indent_size`. |
+| `end_of_line.invalid_value` | A line ending conflicts with `end_of_line`. |
+| `charset.invalid_value` | File bytes do not conform to `charset`. |
+| `trim_trailing_whitespace.present` | Trailing whitespace is present when it must be removed. |
+| `insert_final_newline.missing` | A required final newline is missing. |
+| `max_line_length.exceeded` | A line exceeds `max_line_length`. |
+
+Non-property diagnostics use reserved namespaces: `config.invalid`,
+`io.failed`, `internal.unexpected`, and `selection.skipped`. Codes are stable;
+messages may gain context. Human-readable text is not a machine-readable API.
+An empty selection is reported as `Checked 0 files: no targets selected.`
+
+The string codes replace the earlier `ECCI001`--`ECCI007`, `ECCI-CONFIG`,
+`ECCI-IO`, `ECCI-INTERNAL`, and `ECCI-SKIP` codes. This is a breaking change for
+consumers that matched codes in logs or GitHub Action annotations.
 
 The initial release does not provide JSON or Static Analysis Results
 Interchange Format (SARIF) output. Do not parse the text format as a substitute

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@ set -eu
 
 config_error() {
   escaped=$(printf '%s' "$1" | sed -e 's/%/%25/g' -e 's/\r/%0D/g' -e 's/\n/%0A/g')
-  printf '::error title=ECCI-CONFIG::%s\n' "$escaped"
+  printf '::error title=config.invalid::%s\n' "$escaped"
   if [ -n "${GITHUB_OUTPUT-}" ]; then
     printf 'outcome=configuration-error\nviolations=0\nchecked-files=0\nskipped-files=0\n' >> "$GITHUB_OUTPUT"
   fi


### PR DESCRIPTION
## Summary

- replace numeric property diagnostics with stable `property.kind` identifiers
- reserve non-property namespaces for configuration, I/O, internal, and selection diagnostics
- update CLI and GitHub Action output, regression tests, and user/design documentation
- document the breaking migration from the previous `ECCIxxx` codes

## Testing

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `git diff --check`

This is a breaking diagnostic-output change for consumers that match codes in logs or GitHub Action annotations.