### PR TITLE
Improve property violation diagnostics

### DIFF
--- a/crates/ecci/src/main.rs
+++ b/crates/ecci/src/main.rs
@@ -158,7 +158,7 @@ impl ecci_checker::Output for CheckerOutput<'_> {
         &mut self,
         line: usize,
         start: usize,
-        _length: usize,
+        length: usize,
         path: &str,
         content: &str,
         rule: &str,
@@ -166,13 +166,8 @@ impl ecci_checker::Output for CheckerOutput<'_> {
         let (property, _kind) = rule
             .split_once('.')
             .expect("checker diagnostic codes must use property.kind");
-        let (expected, observed) = finding_values(self.config, property, content, start);
-        let message = match (&expected, &observed) {
-            (Some(expected), Some(observed)) => {
-                format!("{property} must be {expected}; found {observed}")
-            }
-            _ => format!("{property} does not conform"),
-        };
+        let (expected, observed) = finding_values(self.config, property, content, start, length);
+        let message = format_finding_message(property, expected.as_deref(), observed.as_deref());
         let mut finding = Finding::new(rule, property, message);
         finding.expected = expected;
         finding.observed = observed;
@@ -190,19 +185,22 @@ fn finding_values(
     rule: &str,
     content: &str,
     start: usize,
+    length: usize,
 ) -> (Option<String>, Option<String>) {
     let observed = match rule {
         "indent_style" => content
             .as_bytes()
             .get(start)
             .map(|b| if *b == b'\t' { "tab" } else { "space" }.into()),
-        "max_line_length" => Some(
-            content
-                .trim_end_matches(['\r', '\n'])
-                .chars()
-                .count()
-                .to_string(),
-        ),
+        "indent_size" => Some(length.to_string()),
+        "end_of_line" => Some(detected_line_endings(config, content, start)),
+        "charset" => Some(detected_charset_detail(config).into()),
+        "trim_trailing_whitespace" => Some(format!("{length} trailing whitespace bytes")),
+        "insert_final_newline" => Some("final newline absent".into()),
+        "max_line_length" => Some(format!(
+            "{} bytes",
+            content.trim_end_matches(['\r', '\n']).len()
+        )),
         _ => None,
     };
     let expected = match rule {
@@ -216,16 +214,107 @@ fn finding_values(
             ecci_editorconfig::EndOfLine::CRLF => "crlf".into(),
             ecci_editorconfig::EndOfLine::CR => "cr".into(),
         }),
-        "charset" => config
-            .charset
-            .as_ref()
-            .map(|value| format!("{value:?}").to_ascii_lowercase()),
-        "trim_trailing_whitespace" => Some("no trailing whitespace".into()),
-        "insert_final_newline" => Some("a final newline".into()),
+        "charset" => config.charset.as_ref().map(charset_name),
+        "trim_trailing_whitespace" => config
+            .trim_trailing_whitespace
+            .map(|value| value.to_string()),
+        "insert_final_newline" => config.insert_final_newline.map(|value| value.to_string()),
         "max_line_length" => config.max_line_length.map(|value| value.to_string()),
         _ => None,
     };
     (expected, observed)
+}
+
+fn format_finding_message(
+    property: &str,
+    expected: Option<&str>,
+    observed: Option<&str>,
+) -> String {
+    match (expected, observed) {
+        (Some(expected), Some(observed)) => {
+            format!("expected {property}={expected}; detected {property}={observed}")
+        }
+        (Some(expected), None) => {
+            format!("expected {property}={expected}; no detected value available")
+        }
+        (None, Some(observed)) => format!("detected {property}={observed}"),
+        (None, None) => format!("{property} check failed without an observable scalar value"),
+    }
+}
+
+fn detected_line_endings(
+    config: &ecci_editorconfig::Config,
+    content: &str,
+    start: usize,
+) -> String {
+    if let Ok(bytes) = std::fs::read(&config.path) {
+        let mut crlf = 0;
+        let mut cr = 0;
+        let mut lf = 0;
+        let mut index = 0;
+        while index < bytes.len() {
+            match bytes[index..].get(..2) {
+                Some(b"\r\n") => {
+                    crlf += 1;
+                    index += 2;
+                    continue;
+                }
+                _ if bytes[index] == b'\r' => cr += 1,
+                _ if bytes[index] == b'\n' => lf += 1,
+                _ => {}
+            }
+            index += 1;
+        }
+        let kinds = usize::from(crlf > 0) + usize::from(cr > 0) + usize::from(lf > 0);
+        if kinds > 1 {
+            return format!("mixed (crlf={crlf}, cr={cr}, lf={lf})");
+        }
+        if crlf > 0 {
+            return "crlf".into();
+        }
+        if cr > 0 {
+            return "cr".into();
+        }
+        if lf > 0 {
+            return "lf".into();
+        }
+    }
+    match content.as_bytes().get(start..) {
+        Some(bytes) if bytes.starts_with(b"\r\n") => "crlf".into(),
+        Some(bytes) if bytes.starts_with(b"\r") => "cr".into(),
+        Some(bytes) if bytes.starts_with(b"\n") => "lf".into(),
+        _ => "unrecognized line ending".into(),
+    }
+}
+
+fn charset_name(value: &ecci_editorconfig::Charset) -> String {
+    use ecci_editorconfig::Charset;
+    match value {
+        Charset::Latin1 => "latin1",
+        Charset::UTF8 => "utf-8",
+        Charset::UTF8BOM => "utf-8-bom",
+        Charset::UTF16BE => "utf-16be",
+        Charset::UTF16LE => "utf-16le",
+    }
+    .into()
+}
+
+fn detected_charset_detail(config: &ecci_editorconfig::Config) -> &'static str {
+    use ecci_editorconfig::Charset;
+    let Ok(bytes) = std::fs::read(&config.path) else {
+        return "encoding mismatch (bytes unavailable for classification)";
+    };
+    match config.charset.as_ref() {
+        Some(Charset::UTF8) if bytes.starts_with(b"\xef\xbb\xbf") => "utf-8 BOM present",
+        Some(Charset::UTF8) => "invalid utf-8 byte sequence",
+        Some(Charset::UTF8BOM) if !bytes.starts_with(b"\xef\xbb\xbf") => "utf-8 BOM absent",
+        Some(Charset::UTF8BOM) => "invalid utf-8 byte sequence after BOM",
+        Some(Charset::UTF16BE) if bytes.starts_with(b"\xff\xfe") => "utf-16le BOM present",
+        Some(Charset::UTF16LE) if bytes.starts_with(b"\xfe\xff") => "utf-16be BOM present",
+        Some(Charset::UTF16BE | Charset::UTF16LE) if bytes.len() % 2 != 0 => "odd byte count",
+        Some(Charset::UTF16BE | Charset::UTF16LE) => "invalid utf-16 code unit sequence",
+        _ => "encoding mismatch",
+    }
 }
 
 fn skip_message(reason: SkipReason) -> &'static str {

--- a/crates/ecci/tests/action.rs
+++ b/crates/ecci/tests/action.rs
@@ -110,6 +110,9 @@ fn action_emits_escaped_limited_annotations_outputs_and_one_summary() {
         .success()
         .stdout(
             predicate::str::contains("file=a%2C100%25.txt,line=1,col=1")
+                .and(predicate::str::contains(
+                    "expected indent_style=space; detected indent_style=tab",
+                ))
                 .and(predicate::str::contains("1 annotations suppressed")),
         );
     assert_eq!(
@@ -119,6 +122,7 @@ fn action_emits_escaped_limited_annotations_outputs_and_one_summary() {
     let summary = fs::read_to_string(&fixture.summary).unwrap();
     assert_eq!(summary.matches("## ecci").count(), 1);
     assert!(summary.contains("| 2 | 2 | 0 | 0 |"));
+    assert!(summary.contains("expected indent_style=space; detected indent_style=tab"));
 }
 
 #[test]

--- a/crates/ecci/tests/cli.rs
+++ b/crates/ecci/tests/cli.rs
@@ -87,8 +87,35 @@ fn violation_has_stable_code_and_one_based_location() {
         .code(1)
         .stdout("Checked 1 files: 1 violations, 0 skipped, 0 execution errors.\n")
         .stderr(predicate::str::contains(
-            "error[indent_style.invalid_value] target.txt:2:1: indent_style must be space; found tab\n",
+            "error[indent_style.invalid_value] target.txt:2:1: expected indent_style=space; detected indent_style=tab\n",
         ));
+}
+
+#[test]
+fn every_property_violation_reports_expected_and_detected_evidence() {
+    let cases = [
+        ("indent_style = space\n", "\tbad\n", "expected indent_style=space; detected indent_style=tab"),
+        ("indent_style = space\nindent_size = 4\n", "  bad\n", "expected indent_size=4; detected indent_size=2"),
+        ("end_of_line = lf\n", "bad\r\nalso\r", "expected end_of_line=lf; detected end_of_line=mixed (crlf=1, cr=1, lf=0)"),
+        ("charset = utf-8-bom\n", "bad\n", "expected charset=utf-8-bom; detected charset=utf-8 BOM absent"),
+        ("trim_trailing_whitespace = true\n", "bad  \n", "expected trim_trailing_whitespace=true; detected trim_trailing_whitespace=2 trailing whitespace bytes"),
+        ("insert_final_newline = true\n", "bad", "expected insert_final_newline=true; detected insert_final_newline=final newline absent"),
+        ("max_line_length = 3\n", "1234\n", "expected max_line_length=3; detected max_line_length=4 bytes"),
+    ];
+    for (setting, contents, message) in cases {
+        let config = format!("root = true\n[*]\n{setting}");
+        let (temp, target) = project(&config, contents);
+        Command::cargo_bin("ecci")
+            .unwrap()
+            .current_dir(temp.path())
+            .arg(target)
+            .assert()
+            .code(1)
+            .stderr(
+                predicate::str::contains(message)
+                    .and(predicate::str::contains("does not conform").not()),
+            );
+    }
 }
 
 #[test]

--- a/docs/design/cli-diagnostics-and-github-action.md
+++ b/docs/design/cli-diagnostics-and-github-action.md
@@ -7,7 +7,7 @@ command-line interface (CLI) and its GitHub Action. The shared model, text
 renderer, target selection, checker-backed CLI, and Docker Action presentation
 are implemented.
 
-The design distinguishes a **finding** (a checked file does not conform) from
+The design distinguishes a **finding** (a checked file violates a setting) from
 an **execution error** (the command could not reliably complete the requested
 work). This distinction is reflected in both diagnostics and exit status.
 
@@ -66,8 +66,8 @@ default. `--show-skips` requests their `selection.skipped` warning lines; skippe
 remain counted in either mode.
 
 ```text
-error[indent_style.invalid_value] src/lib.rs:14:1: indent_style must be space; found tab
-error[max_line_length.exceeded] src/lib.rs:47:81: max_line_length must be 80; found 96
+error[indent_style.invalid_value] src/lib.rs:14:1: expected indent_style=space; detected indent_style=tab
+error[max_line_length.exceeded] src/lib.rs:47:81: expected max_line_length=80; detected max_line_length=96 bytes
 warning[selection.skipped] docs/generated.md: no .editorconfig applies; skipped
 Checked 2 files: 2 violations, 1 skipped, 0 execution errors.
 ```
@@ -118,7 +118,7 @@ The following cases have these required meanings and text examples:
 
 | Case | Required diagnostic and summary behavior | Example |
 | --- | --- | --- |
-| Violation | Emit one property finding for each reportable violation, retain checking other files, and summarize the count. | `error[indent_style.invalid_value] src/lib.rs:14:1: indent_style must be space; found tab` |
+| Violation | Emit one property finding for each reportable violation, retain checking other files, and summarize the count. | `error[indent_style.invalid_value] src/lib.rs:14:1: expected indent_style=space; detected indent_style=tab` |
 | Configuration error | Emit `error[config.invalid]`; do not claim the affected target was checked. Continue only with independent targets when safe. | `error[config.invalid] .editorconfig:12: invalid indent_size value "many"` |
 | I/O error | Emit `error[io.failed]` with the affected path and operation; do not claim that target was checked. Continue only with independent targets when safe. | `error[io.failed] src/lib.rs: failed to read file: Permission denied` |
 | Internal error | Emit exactly one user-safe `error[internal.unexpected]` summary, without a backtrace by default, and stop normal checking. | `error[internal.unexpected]: unexpected checker failure; rerun with --debug and report this error` |

--- a/docs/user/cli.md
+++ b/docs/user/cli.md
@@ -38,7 +38,7 @@ one-based lines and columns whenever available. The final summary is written to
 standard output.
 
 ```text
-error[indent_style.invalid_value] src/lib.rs:14:1: indent_style must be space; found tab
+error[indent_style.invalid_value] src/lib.rs:14:1: expected indent_style=space; detected indent_style=tab
 Checked 1 files: 1 violations, 0 skipped, 0 execution errors.
 ```
 
@@ -50,7 +50,7 @@ identified without parsing the message. Current codes are:
 | `indent_style.invalid_value` | An indentation character conflicts with `indent_style`. |
 | `indent_size.invalid_value` | Space indentation is not a multiple of `indent_size`. |
 | `end_of_line.invalid_value` | A line ending conflicts with `end_of_line`. |
-| `charset.invalid_value` | File bytes do not conform to `charset`. |
+| `charset.invalid_value` | The detected byte encoding conflicts with `charset`. |
 | `trim_trailing_whitespace.present` | Trailing whitespace is present when it must be removed. |
 | `insert_final_newline.missing` | A required final newline is missing. |
 | `max_line_length.exceeded` | A line exceeds `max_line_length`. |
@@ -58,6 +58,10 @@ identified without parsing the message. Current codes are:
 Non-property diagnostics use reserved namespaces: `config.invalid`,
 `io.failed`, `internal.unexpected`, and `selection.skipped`. Codes are stable;
 messages may gain context. Human-readable text is not a machine-readable API.
+Property findings state the configured expectation and the detected value when
+it is scalar. For non-scalar mismatches they report concrete evidence such as a
+trailing-whitespace byte count, a missing byte-order mark, or an invalid byte
+sequence. GitHub Action annotations and summaries use the same messages.
 An empty selection is reported as `Checked 0 files: no targets selected.`
 
 The string codes replace the earlier `ECCI001`--`ECCI007`, `ECCI-CONFIG`,


### PR DESCRIPTION
## Summary

- replace generic property violation messages with expected and detected values
- report concrete evidence for encoding, line-ending, trailing-whitespace, and other non-scalar mismatches
- keep CLI output, GitHub Action annotations, summaries, tests, and documentation consistent

## Testing

- `cargo test --workspace` (111 passed, 4 ignored)