### PR TITLE
Migrate CLI parsing to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
 
 [[package]]
 name = "assert_cmd"
@@ -62,6 +106,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +193,7 @@ name = "ecci"
 version = "0.0.0"
 dependencies = [
  "assert_cmd",
+ "clap",
  "ecci-checker",
  "ecci-editorconfig",
  "ecci-report",
@@ -193,6 +284,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "ignore"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +304,12 @@ dependencies = [
  "walkdir",
  "winapi-util",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "libc"
@@ -278,6 +381,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "predicates"
@@ -405,6 +514,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +554,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wait-timeout"

--- a/crates/ecci/Cargo.toml
+++ b/crates/ecci/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.5", features = ["derive"] }
 ecci-checker = { version = "0.0.0", path = "../ecci-checker" }
 ecci-editorconfig = { version = "0.0.0", path = "../ecci-editorconfig" }
 ecci-report = { version = "0.0.0", path = "../ecci-report" }

--- a/crates/ecci/src/main.rs
+++ b/crates/ecci/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{ArgAction, Parser};
+use clap::Parser;
 use ecci::selection::{select_paths, ErrorReason, Outcome, SkipReason};
 use ecci_report::{
     render_summary, Diagnostic, ExecutionError, ExecutionErrorKind, Finding, IntentionalSkip,
@@ -10,14 +10,14 @@ use std::path::{Path, PathBuf};
 #[derive(Parser)]
 #[command(disable_help_flag = true, disable_version_flag = true)]
 struct Cli {
-    #[arg(long, action = ArgAction::Count)]
-    github_action: u8,
+    #[arg(long)]
+    github_action: bool,
 
-    #[arg(long, action = ArgAction::Count)]
-    show_skips: u8,
+    #[arg(long)]
+    show_skips: bool,
 
-    #[arg(long, action = ArgAction::Count)]
-    debug: u8,
+    #[arg(long)]
+    debug: bool,
 
     #[arg(value_name = "PATH")]
     paths: Vec<PathBuf>,
@@ -135,23 +135,13 @@ fn parse_args(args: impl IntoIterator<Item = std::ffi::OsString>) -> Result<Opti
     let cli = Cli::try_parse_from(std::iter::once("ecci".into()).chain(args.iter().cloned()))
         .map_err(|_| unsupported_option(&args))?;
 
-    for (name, count) in [
-        ("--github-action", cli.github_action),
-        ("--show-skips", cli.show_skips),
-        ("--debug", cli.debug),
-    ] {
-        if count > 1 {
-            return Err(format!("option {name} may be specified only once"));
-        }
-    }
-
     let mut options = Options {
         paths: cli.paths,
-        show_skips: cli.show_skips == 1,
-        debug: cli.debug == 1,
+        show_skips: cli.show_skips,
+        debug: cli.debug,
         github_action: None,
     };
-    if cli.github_action == 1 {
+    if cli.github_action {
         let action = ecci::action::ActionOptions::from_env()?;
         options.paths = action.paths.clone();
         options.paths.extend(paths_after_github_action(&args));

--- a/crates/ecci/src/main.rs
+++ b/crates/ecci/src/main.rs
@@ -1,13 +1,28 @@
+use clap::{ArgAction, Parser};
 use ecci::selection::{select_paths, ErrorReason, Outcome, SkipReason};
 use ecci_report::{
     render_summary, Diagnostic, ExecutionError, ExecutionErrorKind, Finding, IntentionalSkip,
     Location, Report, SafeDebugDetail, TextRenderOptions,
 };
-use std::ffi::OsString;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 
-#[derive(Default)]
+#[derive(Parser)]
+#[command(disable_help_flag = true, disable_version_flag = true)]
+struct Cli {
+    #[arg(long, action = ArgAction::Count)]
+    github_action: u8,
+
+    #[arg(long, action = ArgAction::Count)]
+    show_skips: u8,
+
+    #[arg(long, action = ArgAction::Count)]
+    debug: u8,
+
+    #[arg(value_name = "PATH")]
+    paths: Vec<PathBuf>,
+}
+
 struct Options {
     paths: Vec<PathBuf>,
     show_skips: bool,
@@ -115,37 +130,71 @@ fn run() -> i32 {
     }
 }
 
-fn parse_args(args: impl Iterator<Item = OsString>) -> Result<Options, String> {
-    let mut options = Options::default();
-    let mut positional_only = false;
-    for arg in args {
-        if !positional_only && arg == "--" {
-            positional_only = true;
-        } else if !positional_only && arg == "--github-action" {
-            if options.github_action.is_some() {
-                return Err("option --github-action may be specified only once".into());
-            }
-            let action = ecci::action::ActionOptions::from_env()?;
-            options.paths = action.paths.clone();
-            options.github_action = Some(action);
-        } else if !positional_only && arg == "--show-skips" {
-            if std::mem::replace(&mut options.show_skips, true) {
-                return Err("option --show-skips may be specified only once".into());
-            }
-        } else if !positional_only && arg == "--debug" {
-            if std::mem::replace(&mut options.debug, true) {
-                return Err("option --debug may be specified only once".into());
-            }
-        } else if !positional_only && arg.to_string_lossy().starts_with('-') {
-            return Err(format!("unsupported option {:?}", arg.to_string_lossy()));
-        } else {
-            options.paths.push(PathBuf::from(arg));
+fn parse_args(args: impl IntoIterator<Item = std::ffi::OsString>) -> Result<Options, String> {
+    let args: Vec<_> = args.into_iter().collect();
+    let cli = Cli::try_parse_from(std::iter::once("ecci".into()).chain(args.iter().cloned()))
+        .map_err(|_| unsupported_option(&args))?;
+
+    for (name, count) in [
+        ("--github-action", cli.github_action),
+        ("--show-skips", cli.show_skips),
+        ("--debug", cli.debug),
+    ] {
+        if count > 1 {
+            return Err(format!("option {name} may be specified only once"));
         }
+    }
+
+    let mut options = Options {
+        paths: cli.paths,
+        show_skips: cli.show_skips == 1,
+        debug: cli.debug == 1,
+        github_action: None,
+    };
+    if cli.github_action == 1 {
+        let action = ecci::action::ActionOptions::from_env()?;
+        options.paths = action.paths.clone();
+        options.paths.extend(paths_after_github_action(&args));
+        options.github_action = Some(action);
     }
     if options.paths.is_empty() {
         options.paths.push(PathBuf::from("."));
     }
     Ok(options)
+}
+
+fn unsupported_option(args: &[std::ffi::OsString]) -> String {
+    let option = args
+        .iter()
+        .take_while(|arg| *arg != "--")
+        .find(|arg| {
+            let arg = arg.to_string_lossy();
+            arg.starts_with('-')
+                && !matches!(arg.as_ref(), "--github-action" | "--show-skips" | "--debug")
+        })
+        .map(|arg| arg.to_string_lossy());
+    match option {
+        Some(option) => format!("unsupported option {option:?}"),
+        None => "invalid command-line arguments".into(),
+    }
+}
+
+fn paths_after_github_action(args: &[std::ffi::OsString]) -> Vec<PathBuf> {
+    let mut action_seen = false;
+    let mut positional_only = false;
+    let mut paths = Vec::new();
+    for arg in args {
+        if !positional_only && arg == "--" {
+            positional_only = true;
+        } else if !positional_only && arg == "--github-action" {
+            action_seen = true;
+            paths.clear();
+        } else if !positional_only && matches!(arg.to_str(), Some("--show-skips" | "--debug")) {
+        } else if action_seen {
+            paths.push(PathBuf::from(arg));
+        }
+    }
+    paths
 }
 
 struct CheckerOutput<'a> {

--- a/crates/ecci/tests/cli.rs
+++ b/crates/ecci/tests/cli.rs
@@ -188,6 +188,21 @@ fn invalid_and_duplicate_controls_are_configuration_errors() {
 }
 
 #[test]
+fn help_and_version_remain_unsupported_options() {
+    for option in ["--help", "--version"] {
+        Command::cargo_bin("ecci")
+            .unwrap()
+            .arg(option)
+            .assert()
+            .code(2)
+            .stdout("Checked 0 files: 0 violations, 0 skipped, 1 execution errors.\n")
+            .stderr(format!(
+                "error[config.invalid]: unsupported option {option:?}\n"
+            ));
+    }
+}
+
+#[test]
 fn release_fixture_covers_encoding_binary_ignore_and_nested_config_semantics() {
     let fixture = release_fixture();
     Command::cargo_bin("ecci")

--- a/docs/user/cli.md
+++ b/docs/user/cli.md
@@ -28,7 +28,9 @@ targets from being processed.
 - `--` ends option processing, allowing a path beginning with `-`.
 
 Options accept no value and may appear only once. Unsupported options and
-duplicate controls are configuration errors.
+duplicate controls are configuration errors. The CLI does not provide `--help`
+or `--version`; both remain unsupported options for compatibility with the
+existing interface.
 
 ## Diagnostics and output
 


### PR DESCRIPTION
## Summary
- migrate CLI argument parsing to clap
- preserve unsupported help/version behavior and exit statuses
- document the compatibility contract and add CLI coverage

## Testing
- cargo fmt --check
- cargo test -p ecci --test cli
- cargo test -p ecci --test action
- cargo test --workspace